### PR TITLE
hotfix(competitions): fix API payload field name for number of players

### DIFF
--- a/src/application/use_cases/competition/CreateCompetitionUseCase.test.js
+++ b/src/application/use_cases/competition/CreateCompetitionUseCase.test.js
@@ -46,7 +46,7 @@ describe('CreateCompetitionUseCase', () => {
       main_country: 'US',
       countries: ['US'],
       handicap_type: 'SCRATCH',
-      max_players: 24,
+      number_of_players: 24,  // API field name (matches backend DTO alias)
       team_assignment: 'manual',
       player_handicap: 'user',
     };

--- a/src/infrastructure/mappers/CompetitionMapper.js
+++ b/src/infrastructure/mappers/CompetitionMapper.js
@@ -49,6 +49,10 @@ class CompetitionMapper {
     // Map team assignment
     const teamAssignment = new TeamAssignment(apiData.team_assignment || 'MANUAL');
 
+    // Bidirectional mapping for maxPlayers/number_of_players
+    // Prefer number_of_players (current API contract), fallback to max_players (legacy)
+    const maxPlayers = apiData.number_of_players ?? apiData.max_players ?? 24;
+
     // Create Competition entity
     return new Competition({
       id: new CompetitionId(apiData.id),
@@ -56,10 +60,10 @@ class CompetitionMapper {
       name: new CompetitionName(apiData.name),
       dates,
       location,
-      team1Name: apiData.team_1_name || apiData.team_one_name || apiData.team1_name || 'Team 1',
+      team1Name: apiData.team_1_name || apiData.team_one_name || apiData.team1_Name || 'Team 1',
       team2Name: apiData.team_2_name || apiData.team_two_name || apiData.team2_name || 'Team 2',
       handicapSettings,
-      maxPlayers: apiData.max_players || 24,
+      maxPlayers,
       teamAssignment,
       status: new CompetitionStatus(apiData.status || 'DRAFT'),
       createdAt: new Date(apiData.created_at),
@@ -89,7 +93,7 @@ class CompetitionMapper {
       countries: competition.location.getAllCountries().slice(1).map(c => c.value()),
       handicap_type: competition.handicapSettings.type(),
       handicap_percentage: competition.handicapSettings.percentage(),
-      max_players: competition.maxPlayers,
+      number_of_players: competition.maxPlayers, // Use API contract field name
       team_assignment: competition.teamAssignment.value(),
       status: competition.status.value,
       creator_id: competition.creatorId

--- a/src/pages/CreateCompetition.jsx
+++ b/src/pages/CreateCompetition.jsx
@@ -272,7 +272,7 @@ const CreateCompetition = () => {
         main_country: formData.country?.code,
         countries: countries,
         handicap_type: formData.handicapType.toUpperCase(),
-        max_players: numPlayers,
+        number_of_players: numPlayers,
         team_assignment: formData.teamAssignment.toUpperCase()
       };
 

--- a/src/utils/sentryHelpers.js
+++ b/src/utils/sentryHelpers.js
@@ -138,7 +138,7 @@ export const setModuleContext = (moduleName, action = null) => {
  *   id: 'comp-123',
  *   name: 'Summer Tournament',
  *   status: 'ACTIVE',
- *   max_players: 20,
+ *   maxPlayers: 20,  // Domain property name
  *   enrolled_count: 15
  * });
  */


### PR DESCRIPTION
Fixed 422 error when creating competitions by changing the payload field from 'max_players' to 'number_of_players' to match backend DTO alias.

The backend expects 'number_of_players' as the JSON field name (alias), while internally it uses 'max_players'. This aligns the frontend with the backend API contract.

Fixes: Competition creation returning 422 Unprocessable Entity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated backend compatibility to use the revised player-count field name.

* **Bug Fixes**
  * Improved robustness of team-name handling and ensured competitions include an updated timestamp.

* **Tests**
  * Adjusted tests to align with the backend field-name change.

* **Documentation**
  * Updated example/context comments to reflect the new domain property naming.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->