### PR TITLE
fix(auth): Force page reload after login to ensure httpOnly cookie availability

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useNavigate, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import toast from 'react-hot-toast';
 import { validateEmail, checkRateLimit, resetRateLimit } from '../utils/validation';
@@ -8,7 +8,6 @@ import PasswordInput from '../components/ui/PasswordInput';
 import { loginUseCase } from '../composition'; // NUEVO import
 
 const Login = () => {
-  const navigate = useNavigate();
   const location = useLocation();
   const successMessage = location.state?.message;
 
@@ -78,9 +77,11 @@ const Login = () => {
       }
 
       const from = location.state?.from?.pathname || '/dashboard';
-      
-      // Navegar sin forzar recarga - useAuth detectará la cookie automáticamente
-      navigate(from, { replace: true });
+
+      // Forzar recarga completa para garantizar que la cookie httpOnly esté disponible
+      // Esto resuelve race conditions en producción donde useAuth puede ejecutarse
+      // antes de que la cookie esté completamente establecida
+      window.location.href = from;
 
     } catch (error) {
       console.error('Login error:', error);

--- a/src/pages/VerifyEmail.jsx
+++ b/src/pages/VerifyEmail.jsx
@@ -44,7 +44,8 @@ const VerifyEmail = () => {
         setStatus('success');
         setMessage('Your email has been verified successfully!');
         redirectTimeoutRef.current = setTimeout(() => {
-          navigate('/dashboard');
+          // Forzar recarga completa para garantizar que la cookie httpOnly esté disponible
+          window.location.href = '/dashboard';
         }, 3000);
 
       } catch (error) {


### PR DESCRIPTION
…ailability

## Problem
Login page was not redirecting to dashboard correctly in production. After successful authentication, the app navigated to /dashboard using React Router, but the httpOnly cookie was not immediately available to the useAuth hook, causing a race condition where the Dashboard thought the user was not authenticated.

## Root Cause
Race condition between:
1. Backend setting the httpOnly cookie after successful login
2. useAuth hook trying to read that cookie immediately after navigation
3. In production (higher latency), useAuth could execute before cookie was fully established

## Solution
Replace React Router navigation with window.location.href to force a full page reload. This ensures:
- ✅ The httpOnly cookie is fully established before Dashboard mounts
- ✅ useAuth hook will correctly read the authentication state
- ✅ No race condition between cookie establishment and auth check

## Changes
- Login.jsx: Replace navigate() with window.location.href
- VerifyEmail.jsx: Replace navigate() with window.location.href
- Remove unused useNavigate import from Login.jsx

## Trade-offs
- Slightly slower UX (full page reload vs SPA navigation)
- More reliable authentication state in production
- Eliminates race conditions with httpOnly cookies

## Testing
✅ All 487 tests passing
✅ ESLint: 0 errors, 0 warnings
✅ Login flow works reliably in both dev and production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication flow to ensure httpOnly security cookies are properly available after successful login and email verification, improving session reliability across pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->