### PR TITLE
docs: Remove reference to non-existent BACKEND_API_SPEC.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,7 @@ npm run preview # probar build
 - **[CHANGELOG.md](CHANGELOG.md)** - Historial detallado de cambios
 - **[ADR-009](docs/architecture/decisions/ADR-009-rbac-system.md)** - Sistema RBAC (roles y permisos)
 - **[ADR-010](docs/architecture/decisions/ADR-010-realtime-scoring-architecture.md)** - Arquitectura de Scoring (polling vs WebSocket)
-- **Backend:** Ver [BACKEND_API_SPEC.md](BACKEND_API_SPEC.md) para la especificación completa del API
-- **API Docs:** [http://localhost:8000/docs](http://localhost:8000/docs)
+- **API Docs:** [http://localhost:8000/docs](http://localhost:8000/docs) - Documentación interactiva del backend
 
 ---
 


### PR DESCRIPTION
- Remove broken link to BACKEND_API_SPEC.md (file is gitignored)
- Consolidate backend documentation reference to API Docs only
- Add clarification that API Docs provides interactive backend documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Backend documentation reference from README.
  * Updated API documentation entries with additional descriptive information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->