### PR TITLE
chore(release): V2.0.2 - Competition Edit & Golf Course Management

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,22 +1,22 @@
 # 🗺️ Roadmap - RyderCupFriends Frontend
 
-> **Versión:** 1.15.0 → 1.16.0 → 2.1.0
+> **Versión:** 1.15.0 → 1.16.0 → 2.0.0 → 2.0.2 → 2.0.3 → 2.0.4 → 2.0.5
 > **Última actualización:** 31 Ene 2026
-> **Estado:** ✅ v1.16.0 Completada (24 Ene 2026) | ✅ v2.1.0 Sprint 1 Completado (31 Ene 2026) | 🔄 Sprint 2 En Curso
+> **Estado:** ✅ v1.16.0 Completada (24 Ene 2026) | ✅ v2.0.0 Sprint 1 Completado (31 Ene 2026) | 🔄 v2.0.2 Sprint 2 En Curso
 > **Stack:** React 19 + Vite 7.3 + Tailwind CSS 4 + ESLint 9
 
 ---
 
-## 🎯 Roadmap v2.1.0 - Sincronización Frontend & Backend
+## 🎯 Roadmap v2.0.0 - Sincronización Frontend & Backend
 
 > **Objetivo:** Convertir la gestión básica de torneos en un sistema completo de planificación, scoring y leaderboards en tiempo real.
 > **Duración:** 7 semanas (27 Ene 2026 - 17 Mar 2026)
-> **Estado:** 🟢 **100% Sincronizado con Backend v2.1.0**
-> **Backend compatible:** FastAPI v2.1.0 (RyderCupAm)
+> **Estado:** 🟢 **100% Sincronizado con Backend v2.0.0**
+> **Backend compatible:** FastAPI v2.0.0 (RyderCupAm)
 
 ---
 
-### 📝 Resumen de Sincronización con Backend (v2.1.0)
+### 📝 Resumen de Sincronización con Backend (v2.0.0)
 
 Tras la revisión del prompt del backend, hemos actualizado nuestro plan para reflejar una sincronización total.
 
@@ -113,14 +113,14 @@ const CompetitionActions = ({ competitionId }) => {
 > **Fechas:** 27 Ene 2026 - 17 Mar 2026
 > **Equipo:** 1 Frontend Dev + 1 Backend Dev (paralelo)
 
-| Sprint   | Fechas          | Esfuerzo BE | Endpoints | Sync Point        | Estado        |
-|----------|-----------------|-------------|-----------|-------------------|---------------|
-| Sprint 1 | 27 Ene - 6 Feb  | 60h         | 10        | ✅ Viernes 31 Ene | ✅ COMPLETADO |
-| Sprint 2 | 7 Feb - 17 Feb  | 70h         | 10        | 🔄 Viernes 14 Feb | 📋 Pendiente  |
-| Sprint 3 | 18 Feb - 24 Feb | 48h         | 5         | 🔄 Viernes 21 Feb | 📋 Pendiente  |
-| Sprint 4 | 25 Feb - 10 Mar | 92h         | 4         | 🔄 Viernes 7 Mar  | 📋 Pendiente  |
-| Sprint 5 | 11 Mar - 17 Mar | 60h         | 2         | 🔄 Viernes 14 Mar | 📋 Pendiente  |
-| **TOTAL**| **7 semanas**   | **330h**    | **31**    |                   |               |
+| Sprint   | Fechas          | Esfuerzo BE | Endpoints | Sync Point        | Estado        | Versión  |
+|----------|-----------------|-------------|-----------|-------------------|---------------|----------|
+| Sprint 1 | 27 Ene - 6 Feb  | 60h         | 10        | ✅ Viernes 31 Ene | ✅ COMPLETADO | v2.0.0   |
+| Sprint 2 | 7 Feb - 17 Feb  | 70h         | 10        | 🔄 Viernes 14 Feb | 🔄 EN CURSO   | v2.0.2   |
+| Sprint 3 | 18 Feb - 24 Feb | 48h         | 5         | 🔄 Viernes 21 Feb | 📋 Pendiente  | v2.0.3   |
+| Sprint 4 | 25 Feb - 10 Mar | 92h         | 4         | 🔄 Viernes 7 Mar  | 📋 Pendiente  | v2.0.4   |
+| Sprint 5 | 11 Mar - 17 Mar | 60h         | 2         | 🔄 Viernes 14 Mar | 📋 Pendiente  | v2.0.5   |
+| **TOTAL**| **7 semanas**   | **330h**    | **31**    |                   |               |          |
 
 ---
 
@@ -253,7 +253,7 @@ Aquí están las confirmaciones y respuestas a vuestras preguntas:
 
 ---
 
-### ✅ Acceptance Criteria Global (v2.1.0)
+### ✅ Acceptance Criteria Global (v2.0.0)
 
 1.  **Funcionalidad:**
     -   ✅ Admin gestiona usuarios y aprueba campos de golf.
@@ -280,7 +280,7 @@ Aquí están las confirmaciones y respuestas a vuestras preguntas:
 
 5.  **Documentation:**
     -   ✅ ADRs actualizados (ADR-009, ADR-010).
-    -   ✅ CHANGELOG.md con v2.1.0 completo.
+    -   ✅ CHANGELOG.md con v2.0.0 completo.
     -   ✅ `ROADMAP.md` sincronizado entre frontend y backend.
 ---
 
@@ -414,5 +414,5 @@ Aquí están las confirmaciones y respuestas a vuestras preguntas:
 
 ---
 
-**Última revisión:** 24 Ene 2026 (v1.16.0 Completada)
-**Próxima revisión:** Inicio v2.1.0
+**Última revisión:** 31 Ene 2026 (v2.0.0 Sprint 1 Completado, Sprint 2 En Curso)
+**Próxima revisión:** Fin Sprint 2 (14 Feb 2026)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@sentry/react": "^10.34.0",
         "axios": "^1.6.2",
         "clsx": "^2.1.1",
@@ -567,6 +570,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "test:security": "playwright test tests/security.spec.js"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@sentry/react": "^10.34.0",
     "axios": "^1.6.2",
     "clsx": "^2.1.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -158,6 +158,7 @@ function AppContent() {
         <Route path="/profile/devices" element={<ProtectedRoute><DeviceManagement /></ProtectedRoute>} />
         <Route path="/competitions" element={<ProtectedRoute><Competitions /></ProtectedRoute>} />
         <Route path="/competitions/create" element={<ProtectedRoute><CreateCompetition /></ProtectedRoute>} />
+        <Route path="/competitions/:id/edit" element={<ProtectedRoute><CreateCompetition /></ProtectedRoute>} />
         <Route path="/competitions/:id" element={<ProtectedRoute><CompetitionDetail /></ProtectedRoute>} />
         <Route path="/browse-competitions" element={<ProtectedRoute><BrowseCompetitions /></ProtectedRoute>} />
 

--- a/src/application/use_cases/competition/AddGolfCourseToCompetitionUseCase.js
+++ b/src/application/use_cases/competition/AddGolfCourseToCompetitionUseCase.js
@@ -1,0 +1,44 @@
+/**
+ * Use Case: Add Golf Course to Competition
+ *
+ * Business Rules:
+ * - Competition must be in DRAFT status
+ * - Golf course must be APPROVED
+ * - Golf course country must be compatible with competition location
+ * - No duplicates allowed
+ */
+class AddGolfCourseToCompetitionUseCase {
+  /**
+   * @param {Object} deps - The dependencies object.
+   * @param {ICompetitionRepository} deps.competitionRepository - The competition repository.
+   */
+  constructor({ competitionRepository }) {
+    this.competitionRepository = competitionRepository;
+  }
+
+  /**
+   * Executes the use case to add a golf course to a competition.
+   *
+   * @param {string} competitionId - The ID of the competition.
+   * @param {string} golfCourseId - The ID of the golf course to add.
+   * @returns {Promise<Object>} - The association details (competition_id, golf_course_id, display_order, added_at).
+   * @throws {Error} If validation fails or operation fails.
+   */
+  async execute(competitionId, golfCourseId) {
+    // Input validation
+    if (!competitionId || typeof competitionId !== 'string') {
+      throw new Error('Competition ID is required and must be a string');
+    }
+
+    if (!golfCourseId || typeof golfCourseId !== 'string') {
+      throw new Error('Golf Course ID is required and must be a string');
+    }
+
+    // Call repository (backend validates business rules)
+    const result = await this.competitionRepository.addGolfCourse(competitionId, golfCourseId);
+
+    return result;
+  }
+}
+
+export default AddGolfCourseToCompetitionUseCase;

--- a/src/application/use_cases/competition/GetCompetitionGolfCoursesUseCase.js
+++ b/src/application/use_cases/competition/GetCompetitionGolfCoursesUseCase.js
@@ -1,0 +1,36 @@
+/**
+ * Use Case: Get Competition Golf Courses
+ *
+ * Retrieves all golf courses associated with a competition,
+ * ordered by display_order.
+ */
+class GetCompetitionGolfCoursesUseCase {
+  /**
+   * @param {Object} deps - The dependencies object.
+   * @param {ICompetitionRepository} deps.competitionRepository - The competition repository.
+   */
+  constructor({ competitionRepository }) {
+    this.competitionRepository = competitionRepository;
+  }
+
+  /**
+   * Executes the use case to get all golf courses for a competition.
+   *
+   * @param {string} competitionId - The ID of the competition.
+   * @returns {Promise<Object>} - Object containing competition_id and golf_courses array.
+   * @throws {Error} If validation fails or operation fails.
+   */
+  async execute(competitionId) {
+    // Input validation
+    if (!competitionId || typeof competitionId !== 'string') {
+      throw new Error('Competition ID is required and must be a string');
+    }
+
+    // Call repository
+    const result = await this.competitionRepository.getCompetitionGolfCourses(competitionId);
+
+    return result;
+  }
+}
+
+export default GetCompetitionGolfCoursesUseCase;

--- a/src/application/use_cases/competition/RemoveGolfCourseFromCompetitionUseCase.js
+++ b/src/application/use_cases/competition/RemoveGolfCourseFromCompetitionUseCase.js
@@ -1,0 +1,43 @@
+/**
+ * Use Case: Remove Golf Course from Competition
+ *
+ * Business Rules:
+ * - Competition must be in DRAFT status
+ * - Golf course must be associated with the competition
+ * - Display order of remaining courses is automatically recalculated
+ */
+class RemoveGolfCourseFromCompetitionUseCase {
+  /**
+   * @param {Object} deps - The dependencies object.
+   * @param {ICompetitionRepository} deps.competitionRepository - The competition repository.
+   */
+  constructor({ competitionRepository }) {
+    this.competitionRepository = competitionRepository;
+  }
+
+  /**
+   * Executes the use case to remove a golf course from a competition.
+   *
+   * @param {string} competitionId - The ID of the competition.
+   * @param {string} golfCourseId - The ID of the golf course to remove.
+   * @returns {Promise<Object>} - The removal confirmation (competition_id, golf_course_id, removed_at).
+   * @throws {Error} If validation fails or operation fails.
+   */
+  async execute(competitionId, golfCourseId) {
+    // Input validation
+    if (!competitionId || typeof competitionId !== 'string') {
+      throw new Error('Competition ID is required and must be a string');
+    }
+
+    if (!golfCourseId || typeof golfCourseId !== 'string') {
+      throw new Error('Golf Course ID is required and must be a string');
+    }
+
+    // Call repository (backend validates business rules)
+    const result = await this.competitionRepository.removeGolfCourse(competitionId, golfCourseId);
+
+    return result;
+  }
+}
+
+export default RemoveGolfCourseFromCompetitionUseCase;

--- a/src/application/use_cases/competition/ReorderGolfCoursesUseCase.js
+++ b/src/application/use_cases/competition/ReorderGolfCoursesUseCase.js
@@ -1,0 +1,60 @@
+/**
+ * Use Case: Reorder Golf Courses in Competition
+ *
+ * Business Rules:
+ * - Competition must be in DRAFT status
+ * - Must include ALL golf course IDs currently associated
+ * - No duplicate IDs allowed
+ * - All IDs must exist in the competition
+ */
+class ReorderGolfCoursesUseCase {
+  /**
+   * @param {Object} deps - The dependencies object.
+   * @param {ICompetitionRepository} deps.competitionRepository - The competition repository.
+   */
+  constructor({ competitionRepository }) {
+    this.competitionRepository = competitionRepository;
+  }
+
+  /**
+   * Executes the use case to reorder golf courses in a competition.
+   *
+   * @param {string} competitionId - The ID of the competition.
+   * @param {string[]} golfCourseIds - Array of golf course IDs in the new order.
+   * @returns {Promise<Object>} - The reordered golf courses with display_order.
+   * @throws {Error} If validation fails or operation fails.
+   */
+  async execute(competitionId, golfCourseIds) {
+    // Input validation
+    if (!competitionId || typeof competitionId !== 'string') {
+      throw new Error('Competition ID is required and must be a string');
+    }
+
+    if (!Array.isArray(golfCourseIds)) {
+      throw new Error('Golf Course IDs must be an array');
+    }
+
+    if (golfCourseIds.length === 0) {
+      throw new Error('Golf Course IDs array cannot be empty');
+    }
+
+    // Check for duplicates
+    const uniqueIds = new Set(golfCourseIds);
+    if (uniqueIds.size !== golfCourseIds.length) {
+      throw new Error('Duplicate golf course IDs found in the array');
+    }
+
+    // Validate all IDs are strings
+    const allStrings = golfCourseIds.every(id => typeof id === 'string' && id.length > 0);
+    if (!allStrings) {
+      throw new Error('All golf course IDs must be non-empty strings');
+    }
+
+    // Call repository (backend validates business rules)
+    const result = await this.competitionRepository.reorderGolfCourses(competitionId, golfCourseIds);
+
+    return result;
+  }
+}
+
+export default ReorderGolfCoursesUseCase;

--- a/src/application/use_cases/competition/UpdateCompetitionUseCase.js
+++ b/src/application/use_cases/competition/UpdateCompetitionUseCase.js
@@ -1,0 +1,91 @@
+/**
+ * Use Case: Update Competition
+ *
+ * Business Rules:
+ * - Only creator of the competition can update it (backend validates)
+ * - Can only update competitions in DRAFT status (backend validates)
+ * - Cannot change competition name to one that already exists
+ */
+class UpdateCompetitionUseCase {
+  /**
+   * @param {Object} deps - The dependencies object.
+   * @param {ICompetitionRepository} deps.competitionRepository - The competition repository.
+   */
+  constructor({ competitionRepository }) {
+    this.competitionRepository = competitionRepository;
+  }
+
+  /**
+   * Executes the use case to update a competition.
+   *
+   * @param {string} competitionId - The ID of the competition to update.
+   * @param {Object} competitionData - The updated competition data.
+   * @param {string} competitionData.name - The competition name.
+   * @param {string} competitionData.team_1_name - Team 1 name.
+   * @param {string} competitionData.team_2_name - Team 2 name.
+   * @param {string} competitionData.start_date - Start date (YYYY-MM-DD).
+   * @param {string} competitionData.end_date - End date (YYYY-MM-DD).
+   * @param {string} competitionData.main_country - Main country ISO code.
+   * @param {Array} competitionData.countries - Array of adjacent countries.
+   * @param {string} competitionData.handicap_type - Handicap type.
+   * @param {number} competitionData.number_of_players - Number of players.
+   * @param {string} competitionData.team_assignment - Team assignment method.
+   * @returns {Promise<Object>} - The updated competition object.
+   * @throws {Error} If validation fails or operation fails.
+   */
+  async execute(competitionId, competitionData) {
+    // Input validation
+    if (!competitionId || typeof competitionId !== 'string') {
+      throw new Error('Competition ID is required and must be a string');
+    }
+
+    if (!competitionData || typeof competitionData !== 'object') {
+      throw new Error('Competition data is required and must be an object');
+    }
+
+    // Validate required fields
+    if (!competitionData.name || competitionData.name.trim().length < 3) {
+      throw new Error('Competition name must be at least 3 characters');
+    }
+
+    if (!competitionData.team_1_name || competitionData.team_1_name.trim().length === 0) {
+      throw new Error('Team 1 name is required');
+    }
+
+    if (!competitionData.team_2_name || competitionData.team_2_name.trim().length === 0) {
+      throw new Error('Team 2 name is required');
+    }
+
+    if (!competitionData.start_date) {
+      throw new Error('Start date is required');
+    }
+
+    if (!competitionData.end_date) {
+      throw new Error('End date is required');
+    }
+
+    // Validate dates
+    const startDate = new Date(competitionData.start_date);
+    const endDate = new Date(competitionData.end_date);
+
+    // Check for Invalid Date
+    if (isNaN(startDate.getTime())) {
+      throw new Error('Invalid start_date');
+    }
+
+    if (isNaN(endDate.getTime())) {
+      throw new Error('Invalid end_date');
+    }
+
+    if (endDate <= startDate) {
+      throw new Error('End date must be after start date');
+    }
+
+    // Call repository (backend validates business rules like ownership and status)
+    const competition = await this.competitionRepository.updateCompetition(competitionId, competitionData);
+
+    return competition;
+  }
+}
+
+export default UpdateCompetitionUseCase;

--- a/src/application/use_cases/golf_course/CreateGolfCourseRequestUseCase.js
+++ b/src/application/use_cases/golf_course/CreateGolfCourseRequestUseCase.js
@@ -29,8 +29,8 @@ class CreateGolfCourseRequestUseCase {
       throw new Error('Golf course name is required and must be a non-empty string');
     }
 
-    // Validate country
-    if (!golfCourseData.country) {
+    // Validate country code
+    if (!golfCourseData.countryCode || typeof golfCourseData.countryCode !== 'string' || golfCourseData.countryCode.length !== 2) {
       throw new Error('Golf course country is required');
     }
 
@@ -44,7 +44,7 @@ class CreateGolfCourseRequestUseCase {
       if (!tee.identifier || typeof tee.identifier !== 'string') {
         throw new Error(`Tee ${index + 1} must have a valid identifier`);
       }
-      if (!tee.category) {
+      if (!tee.teeCategory) {
         throw new Error(`Tee ${index + 1} must have a category`);
       }
       if (typeof tee.slopeRating !== 'number') {
@@ -52,9 +52,6 @@ class CreateGolfCourseRequestUseCase {
       }
       if (typeof tee.courseRating !== 'number') {
         throw new Error(`Tee ${index + 1} must have a numeric course rating`);
-      }
-      if (!tee.gender) {
-        throw new Error(`Tee ${index + 1} must have a gender`);
       }
     });
 

--- a/src/components/auth/RoleGuard.jsx
+++ b/src/components/auth/RoleGuard.jsx
@@ -68,10 +68,23 @@ const RoleGuard = ({
   }
 
   // Extract user's role names
-  // Handle both structures: user.roles = [{ name: 'ADMIN' }] or user.roles = ['ADMIN']
-  const userRoleNames = user.roles?.map(role =>
-    typeof role === 'string' ? role : role.name
-  ) || [];
+  // Support multiple backend formats (RBAC simplified - see ROADMAP.md):
+  // 1. user.is_admin = true (current backend format for global admin access)
+  // 2. user.roles = [{ name: 'ADMIN' }] or ['ADMIN'] (future format)
+  let userRoleNames = [];
+
+  // Check for global admin flag (current backend implementation)
+  if (user.is_admin === true) {
+    userRoleNames.push('ADMIN');
+  }
+
+  // Check for roles array (future implementation)
+  if (user.roles && Array.isArray(user.roles)) {
+    const rolesFromArray = user.roles.map(role =>
+      typeof role === 'string' ? role : role.name
+    );
+    userRoleNames = [...new Set([...userRoleNames, ...rolesFromArray])];
+  }
 
   // Check if user has required role(s)
   const hasAccess = requireAll

--- a/src/components/competition/CompetitionGolfCoursesSection.jsx
+++ b/src/components/competition/CompetitionGolfCoursesSection.jsx
@@ -1,0 +1,354 @@
+import { useState, useEffect } from 'react';
+import { Flag, Plus, Trash2, GripVertical, MapPin, Loader } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { CountryFlag } from '../../utils/countryUtils';
+import { formatCountryName } from '../../services/countries';
+import GolfCourseSearchBox from '../golf_course/GolfCourseSearchBox';
+import customToast from '../../utils/toast';
+import {
+  getCompetitionGolfCoursesUseCase,
+  addGolfCourseToCompetitionUseCase,
+  removeGolfCourseFromCompetitionUseCase,
+  reorderGolfCoursesUseCase,
+} from '../../composition';
+
+/**
+ * Sortable Item Component (used by dnd-kit)
+ */
+const SortableGolfCourseItem = ({ course, onRemove, canEdit, i18n }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: course.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center gap-3 p-4 bg-white border border-gray-200 rounded-lg ${
+        isDragging ? 'shadow-lg' : ''
+      }`}
+    >
+      {/* Drag Handle (only visible in edit mode) */}
+      {canEdit && (
+        <div
+          {...attributes}
+          {...listeners}
+          className="cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600"
+        >
+          <GripVertical className="w-5 h-5" />
+        </div>
+      )}
+
+      {/* Course Info */}
+      <div className="flex-1 min-w-0">
+        {/* Course Name */}
+        <h4 className="text-lg font-semibold text-gray-900 truncate mb-2">
+          {course.name || `Golf Course (ID: ${course.id?.substring(0, 8)}...)`}
+        </h4>
+
+        {/* Course Details */}
+        <div className="flex flex-wrap items-center gap-3">
+          {/* Country Badge */}
+          {course.country_code && (
+            <div className="flex items-center gap-2 px-3 py-1 bg-blue-50 rounded-full">
+              <CountryFlag countryCode={course.country_code} style={{ width: '18px', height: 'auto' }} />
+              <span className="text-sm font-medium text-blue-900">
+                {formatCountryName({ code: course.country_code, name_en: course.country_name }, i18n.language)}
+              </span>
+            </div>
+          )}
+
+          {/* Course Type Badge */}
+          {course.course_type && (
+            <div className="px-3 py-1 bg-green-50 rounded-full">
+              <span className="text-sm font-medium text-green-900">
+                {course.course_type === 'STANDARD_18' ? '18 Holes' :
+                 course.course_type === 'PITCH_AND_PUTT' ? 'Pitch & Putt' :
+                 course.course_type === 'EXECUTIVE' ? 'Executive' : course.course_type}
+              </span>
+            </div>
+          )}
+
+          {/* Par Badge */}
+          {course.total_par > 0 && (
+            <div className="px-3 py-1 bg-purple-50 rounded-full">
+              <span className="text-sm font-medium text-purple-900">Par {course.total_par}</span>
+            </div>
+          )}
+
+          {/* No data fallback */}
+          {!course.country_code && (
+            <span className="text-sm text-gray-500 italic">Details not loaded</span>
+          )}
+        </div>
+      </div>
+
+      {/* Remove Button (only visible in edit mode) */}
+      {canEdit && (
+        <button
+          onClick={() => onRemove(course.id)}
+          className="p-2 text-red-500 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors"
+          title="Remove golf course"
+        >
+          <Trash2 className="w-5 h-5" />
+        </button>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Competition Golf Courses Section Component
+ *
+ * Features:
+ * - Display golf courses ordered by display_order
+ * - Drag & drop reordering (only in DRAFT status for creators)
+ * - Add new golf courses (only in DRAFT status for creators)
+ * - Remove golf courses (only in DRAFT status for creators)
+ */
+const CompetitionGolfCoursesSection = ({ competition, canManage }) => {
+  const { t, i18n } = useTranslation('competitions');
+  const [golfCourses, setGolfCourses] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isAdding, setIsAdding] = useState(false);
+  const [showAddForm, setShowAddForm] = useState(false);
+
+  // dnd-kit sensors
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const canEdit = canManage && competition.status === 'DRAFT';
+
+  // Get compatible countries for the search box
+  // Use main_country if available, otherwise fallback to first country in countries array
+  const mainCountryCode = competition.location || competition.countries?.[0]?.code;
+  const compatibleCountries = [
+    mainCountryCode,
+    ...(competition.countries?.slice(1).map(c => c.code) || [])
+  ].filter(Boolean);
+
+  // Load golf courses
+  useEffect(() => {
+    loadGolfCourses();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [competition.id]);
+
+  const loadGolfCourses = async () => {
+    setIsLoading(true);
+    try {
+      const result = await getCompetitionGolfCoursesUseCase.execute(competition.id);
+
+      // Backend returns array with structure: { golf_course_id, display_order, created_at, golf_course: {...} }
+      // Flatten the structure for easier access in the UI
+      const courses = Array.isArray(result) ? result : (result.golf_courses || []);
+      const mappedCourses = courses.map(item => ({
+        ...item.golf_course, // Spread golf course data (id, name, country_code, etc.)
+        display_order: item.display_order,
+        created_at: item.created_at,
+        golf_course_id: item.golf_course_id, // Keep reference ID
+      }));
+
+      setGolfCourses(mappedCourses);
+    } catch (error) {
+      console.error('Error loading golf courses:', error);
+      customToast.error(t('detail.golfCourses.errorLoading') + ': ' + error.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleAddCourse = async (course) => {
+    setIsAdding(true);
+    try {
+      await addGolfCourseToCompetitionUseCase.execute(competition.id, course.id);
+      customToast.success(t('detail.golfCourses.courseAdded'));
+      setShowAddForm(false);
+      await loadGolfCourses();
+    } catch (error) {
+      console.error('Error adding golf course:', error);
+      customToast.error(error.message || t('detail.golfCourses.errorAdding'));
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  const handleRemoveCourse = async (courseId) => {
+    if (!window.confirm(t('detail.golfCourses.confirmRemove'))) {
+      return;
+    }
+
+    try {
+      await removeGolfCourseFromCompetitionUseCase.execute(competition.id, courseId);
+      customToast.success(t('detail.golfCourses.courseRemoved'));
+      await loadGolfCourses();
+    } catch (error) {
+      console.error('Error removing golf course:', error);
+      customToast.error(error.message || t('detail.golfCourses.errorRemoving'));
+    }
+  };
+
+  const handleDragEnd = async (event) => {
+    const { active, over } = event;
+
+    if (!over || active.id === over.id) {
+      return;
+    }
+
+    const oldIndex = golfCourses.findIndex((course) => course.id === active.id);
+    const newIndex = golfCourses.findIndex((course) => course.id === over.id);
+
+    // Optimistic UI update
+    const newOrder = arrayMove(golfCourses, oldIndex, newIndex);
+    setGolfCourses(newOrder);
+
+    try {
+      // Send new order to backend
+      const courseIds = newOrder.map(course => course.id);
+      await reorderGolfCoursesUseCase.execute(competition.id, courseIds);
+      customToast.success(t('detail.golfCourses.reordered'));
+    } catch (error) {
+      console.error('Error reordering golf courses:', error);
+      customToast.error(t('detail.golfCourses.errorReordering'));
+      // Revert on error
+      await loadGolfCourses();
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-4">
+        <div className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+          <div className="flex items-center justify-center py-8">
+            <Loader className="w-8 h-8 text-primary animate-spin" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4">
+      <div className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-gray-900 font-bold text-lg flex items-center gap-2">
+            <Flag className="w-5 h-5 text-green-600" />
+            {t('detail.golfCourses.title', { count: golfCourses.length })}
+          </h3>
+          {canEdit && !showAddForm && (
+            <button
+              onClick={() => setShowAddForm(true)}
+              className="flex items-center gap-2 px-4 py-2 bg-primary text-white rounded-lg text-sm font-medium hover:bg-primary/90 transition-colors"
+            >
+              <Plus className="w-4 h-4" />
+              {t('detail.golfCourses.addCourse')}
+            </button>
+          )}
+        </div>
+
+        {/* Add Course Form */}
+        {showAddForm && (
+          <div className="mb-4 p-4 bg-gray-50 border border-gray-200 rounded-lg">
+            <div className="flex items-center justify-between mb-3">
+              <h4 className="text-sm font-semibold text-gray-900">
+                {t('detail.golfCourses.selectCourse')}
+              </h4>
+              <button
+                onClick={() => setShowAddForm(false)}
+                className="text-gray-500 hover:text-gray-700"
+                disabled={isAdding}
+              >
+                ✕
+              </button>
+            </div>
+            <GolfCourseSearchBox
+              countryCode={compatibleCountries[0] || null}
+              selectedCourse={null}
+              onCourseSelect={handleAddCourse}
+              onRequestNewCourse={() => {
+                customToast.info(t('detail.golfCourses.requestNotAvailable'));
+              }}
+            />
+            {isAdding && (
+              <div className="mt-2 flex items-center gap-2 text-sm text-gray-600">
+                <Loader className="w-4 h-4 animate-spin" />
+                <span>{t('detail.golfCourses.adding')}</span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Golf Courses List */}
+        {golfCourses.length === 0 ? (
+          <div className="text-center py-8 text-gray-500">
+            <MapPin className="w-12 h-12 mx-auto mb-2 opacity-50" />
+            <p>{t('detail.golfCourses.noCourses')}</p>
+          </div>
+        ) : (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={golfCourses.map(c => c.id)}
+              strategy={verticalListSortingStrategy}
+              disabled={!canEdit}
+            >
+              <div className="space-y-2">
+                {golfCourses.map((course) => (
+                  <SortableGolfCourseItem
+                    key={course.id}
+                    course={course}
+                    onRemove={handleRemoveCourse}
+                    canEdit={canEdit}
+                    i18n={i18n}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+        )}
+
+        {/* Helper text for drag & drop */}
+        {canEdit && golfCourses.length > 1 && (
+          <p className="mt-4 text-xs text-gray-500 text-center">
+            {t('detail.golfCourses.dragToReorder')}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CompetitionGolfCoursesSection;

--- a/src/components/golf_course/GolfCourseForm.jsx
+++ b/src/components/golf_course/GolfCourseForm.jsx
@@ -51,7 +51,7 @@ const GolfCourseForm = ({ initialData = null, onSubmit, onCancel }) => {
 
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // Load countries on mount
+  // Load countries on mount (only once)
   useEffect(() => {
     const fetchCountries = async () => {
       try {
@@ -61,7 +61,6 @@ const GolfCourseForm = ({ initialData = null, onSubmit, onCancel }) => {
               .filter(c => c?.code && (c?.name_en || c?.name_es))
               .map(c => ({
                 id: c.code,
-                name: c.name_en || c.name_es,
                 code: c.code,
                 name_en: c.name_en,
                 name_es: c.name_es
@@ -236,8 +235,6 @@ const GolfCourseForm = ({ initialData = null, onSubmit, onCancel }) => {
         })),
       };
 
-      console.log('📝 Form Data before submit:', formData);
-
       await onSubmit(formData);
     } catch (error) {
       console.error('Error submitting form:', error);
@@ -288,7 +285,7 @@ const GolfCourseForm = ({ initialData = null, onSubmit, onCancel }) => {
                 }`}
                 required
               >
-                <option value="">{t('form.selectCountry', 'Select country...')}</option>
+                <option value="">{t('form.selectCountry')}</option>
                 {allCountries.map((country) => (
                   <option key={country.code} value={country.code}>
                     {formatCountryName(country, i18n.language)}

--- a/src/composition/index.js
+++ b/src/composition/index.js
@@ -41,6 +41,7 @@ import RevokeDeviceUseCase from '../application/use_cases/device/RevokeDeviceUse
 // Competition Use Cases
 import ApiCompetitionRepository from '../infrastructure/repositories/ApiCompetitionRepository';
 import CreateCompetitionUseCase from '../application/use_cases/competition/CreateCompetitionUseCase';
+import UpdateCompetitionUseCase from '../application/use_cases/competition/UpdateCompetitionUseCase';
 import ListUserCompetitionsUseCase from '../application/use_cases/competition/ListUserCompetitionsUseCase';
 import GetCompetitionDetailUseCase from '../application/use_cases/competition/GetCompetitionDetailUseCase';
 import ActivateCompetitionUseCase from '../application/use_cases/competition/ActivateCompetitionUseCase';
@@ -50,6 +51,10 @@ import CompleteCompetitionUseCase from '../application/use_cases/competition/Com
 import CancelCompetitionUseCase from '../application/use_cases/competition/CancelCompetitionUseCase';
 import BrowseJoinableCompetitionsUseCase from '../application/use_cases/competition/BrowseJoinableCompetitionsUseCase';
 import BrowseExploreCompetitionsUseCase from '../application/use_cases/competition/BrowseExploreCompetitionsUseCase';
+import AddGolfCourseToCompetitionUseCase from '../application/use_cases/competition/AddGolfCourseToCompetitionUseCase';
+import RemoveGolfCourseFromCompetitionUseCase from '../application/use_cases/competition/RemoveGolfCourseFromCompetitionUseCase';
+import ReorderGolfCoursesUseCase from '../application/use_cases/competition/ReorderGolfCoursesUseCase';
+import GetCompetitionGolfCoursesUseCase from '../application/use_cases/competition/GetCompetitionGolfCoursesUseCase';
 
 // Enrollment Use Cases
 import ApiEnrollmentRepository from '../infrastructure/repositories/ApiEnrollmentRepository';
@@ -89,6 +94,7 @@ const requestPasswordResetUseCase = new RequestPasswordResetUseCase({ authReposi
 const validateResetTokenUseCase = new ValidateResetTokenUseCase({ authRepository: apiAuthRepository });
 const resetPasswordUseCase = new ResetPasswordUseCase({ authRepository: apiAuthRepository });
 const createCompetitionUseCase = new CreateCompetitionUseCase({ competitionRepository: apiCompetitionRepository });
+const updateCompetitionUseCase = new UpdateCompetitionUseCase({ competitionRepository: apiCompetitionRepository });
 const listUserCompetitionsUseCase = new ListUserCompetitionsUseCase({ competitionRepository: apiCompetitionRepository });
 const getCompetitionDetailUseCase = new GetCompetitionDetailUseCase({ competitionRepository: apiCompetitionRepository });
 const activateCompetitionUseCase = new ActivateCompetitionUseCase();
@@ -98,6 +104,10 @@ const completeCompetitionUseCase = new CompleteCompetitionUseCase();
 const cancelCompetitionUseCase = new CancelCompetitionUseCase();
 const browseJoinableCompetitionsUseCase = new BrowseJoinableCompetitionsUseCase(apiCompetitionRepository);
 const browseExploreCompetitionsUseCase = new BrowseExploreCompetitionsUseCase(apiCompetitionRepository);
+const addGolfCourseToCompetitionUseCase = new AddGolfCourseToCompetitionUseCase({ competitionRepository: apiCompetitionRepository });
+const removeGolfCourseFromCompetitionUseCase = new RemoveGolfCourseFromCompetitionUseCase({ competitionRepository: apiCompetitionRepository });
+const reorderGolfCoursesUseCase = new ReorderGolfCoursesUseCase({ competitionRepository: apiCompetitionRepository });
+const getCompetitionGolfCoursesUseCase = new GetCompetitionGolfCoursesUseCase({ competitionRepository: apiCompetitionRepository });
 const fetchCountriesUseCase = new FetchCountriesUseCase();
 
 // Enrollment Use Cases
@@ -140,6 +150,7 @@ export {
   validateResetTokenUseCase,
   resetPasswordUseCase,
   createCompetitionUseCase,
+  updateCompetitionUseCase,
   listUserCompetitionsUseCase,
   getCompetitionDetailUseCase,
   activateCompetitionUseCase,
@@ -149,6 +160,10 @@ export {
   cancelCompetitionUseCase,
   browseJoinableCompetitionsUseCase,
   browseExploreCompetitionsUseCase,
+  addGolfCourseToCompetitionUseCase,
+  removeGolfCourseFromCompetitionUseCase,
+  reorderGolfCoursesUseCase,
+  getCompetitionGolfCoursesUseCase,
   // Country Use Cases
   fetchCountriesUseCase,
   // Enrollment Use Cases

--- a/src/domain/repositories/ICompetitionRepository.js
+++ b/src/domain/repositories/ICompetitionRepository.js
@@ -87,4 +87,67 @@ class ICompetitionRepository {
   async findPublic(filters = {}) {
     throw new Error('ICompetitionRepository.findPublic must be implemented');
   }
+
+  /**
+   * Adds a golf course to a competition.
+   * Only allowed when competition status is DRAFT.
+   *
+   * @param {string} competitionId The ID of the competition.
+   * @param {string} golfCourseId The ID of the golf course to add.
+   * @returns {Promise<object>} The association details (competition_id, golf_course_id, display_order, added_at).
+   * @throws {Error} If the method is not implemented.
+   */
+  async addGolfCourse(competitionId, golfCourseId) {
+    throw new Error('ICompetitionRepository.addGolfCourse must be implemented');
+  }
+
+  /**
+   * Removes a golf course from a competition.
+   * Only allowed when competition status is DRAFT.
+   *
+   * @param {string} competitionId The ID of the competition.
+   * @param {string} golfCourseId The ID of the golf course to remove.
+   * @returns {Promise<object>} The removal confirmation (competition_id, golf_course_id, removed_at).
+   * @throws {Error} If the method is not implemented.
+   */
+  async removeGolfCourse(competitionId, golfCourseId) {
+    throw new Error('ICompetitionRepository.removeGolfCourse must be implemented');
+  }
+
+  /**
+   * Reorders golf courses in a competition.
+   * Only allowed when competition status is DRAFT.
+   *
+   * @param {string} competitionId The ID of the competition.
+   * @param {string[]} golfCourseIds Array of golf course IDs in the new order.
+   * @returns {Promise<object>} The reordered golf courses with display_order.
+   * @throws {Error} If the method is not implemented.
+   */
+  async reorderGolfCourses(competitionId, golfCourseIds) {
+    throw new Error('ICompetitionRepository.reorderGolfCourses must be implemented');
+  }
+
+  /**
+   * Gets all golf courses associated with a competition.
+   *
+   * @param {string} competitionId The ID of the competition.
+   * @returns {Promise<object>} Object containing competition_id and golf_courses array.
+   * @throws {Error} If the method is not implemented.
+   */
+  async getCompetitionGolfCourses(competitionId) {
+    throw new Error('ICompetitionRepository.getCompetitionGolfCourses must be implemented');
+  }
+
+  /**
+   * Updates a competition.
+   * Only allowed when competition status is DRAFT and user is the creator.
+   *
+   * @param {string} competitionId The ID of the competition to update.
+   * @param {object} competitionData The updated competition data.
+   * @returns {Promise<Competition>} The updated competition entity.
+   * @throws {Error} If the method is not implemented.
+   */
+  async updateCompetition(competitionId, competitionData) {
+    throw new Error('ICompetitionRepository.updateCompetition must be implemented');
+  }
 }

--- a/src/i18n/config.js
+++ b/src/i18n/config.js
@@ -4,14 +4,12 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 
 // Custom backend para lazy loading de traducciones
 // Reduce bundle inicial de ~313 KB a ~40 KB (solo carga common en idioma detectado)
-class LazyBackend {
-  constructor() {
-    this.type = 'backend';
-  }
+const LazyBackend = {
+  type: 'backend',
 
   init() {
     // No-op - required by i18next backend interface
-  }
+  },
 
   read(language, namespace, callback) {
     // Dynamic import solo del archivo necesario
@@ -24,7 +22,7 @@ class LazyBackend {
         callback(error, null);
       });
   }
-}
+};
 
 i18n
   .use(LazyBackend) // Custom backend para lazy loading

--- a/src/i18n/locales/en/competitions.json
+++ b/src/i18n/locales/en/competitions.json
@@ -22,7 +22,11 @@
     "pendingRequest": "pending request",
     "pendingRequests": "pending requests",
     "enrollmentStatus": "Enrollment: {{status}}",
-    "players": "{{count}} / {{max}} players"
+    "players": "{{count}} / {{max}} players",
+    "golfCoursesCount": "{{count}} golf course",
+    "golfCoursesCount_plural": "{{count}} golf courses",
+    "countriesCount": "{{count}} country",
+    "countriesCount_plural": "{{count}} countries"
   },
   "create": {
     "title": "Create Competition",
@@ -79,7 +83,19 @@
       "playersMinimum": "Number of players must be at least 2",
       "playersMaximum": "Number of players cannot exceed 100"
     },
-    "success": "Competition created successfully!"
+    "success": "Competition created successfully!",
+    "partialSuccess": "Competition created, but {{failed}} course(s) could not be added: {{courses}}. {{success}} course(s) were added successfully.",
+    "errorAddingCourses": "Competition created, but golf courses could not be added. You can add them manually from the detail page.",
+    "error": "Failed to create competition"
+  },
+  "edit": {
+    "title": "Edit Competition",
+    "loading": "Loading competition...",
+    "updating": "Updating...",
+    "updateCompetition": "Update Competition",
+    "success": "Competition updated successfully!",
+    "error": "Failed to update competition",
+    "errorLoading": "Failed to load competition"
   },
   "detail": {
     "loadingCompetition": "Loading competition...",
@@ -93,21 +109,21 @@
     "actions": {
       "edit": "Edit",
       "activate": "Activate",
-      "closeEnrollments": "Close Enrollments",
-      "startCompetition": "Start Competition",
+      "close-enrollments": "Close Enrollments",
+      "start-competition": "Start Competition",
       "complete": "Complete",
       "cancel": "Cancel",
       "delete": "Delete",
-      "requestToJoin": "Request to Join"
+      "request-to-join": "Request to Join"
     },
     "confirmations": {
       "activate": "Are you sure you want to activate this competition?",
-      "closeEnrollments": "Are you sure you want to close-enrollments this competition?",
+      "close-enrollments": "Are you sure you want to close enrollments for this competition?",
       "start": "Are you sure you want to start this competition?",
       "complete": "Are you sure you want to complete this competition?",
       "cancel": "Are you sure you want to cancel this competition?",
       "delete": "Are you sure you want to delete this competition? This action cannot be undone.",
-      "rejectEnrollment": "Are you sure you want to reject this enrollment?"
+      "reject-enrollment": "Are you sure you want to reject this enrollment?"
     },
     "errors": {
       "golfCoursePendingApproval": "Cannot activate competition: Golf course is pending approval",
@@ -139,12 +155,38 @@
     "rejected": "REJECTED",
     "enrollmentApproved": "Enrollment approved",
     "enrollmentRejected": "Enrollment rejected",
+    "success": {
+      "activated": "Competition activated successfully",
+      "enrollmentsClosed": "Enrollments closed successfully",
+      "started": "Competition started successfully",
+      "completed": "Competition completed successfully",
+      "cancelled": "Competition cancelled successfully",
+      "deleted": "Competition deleted successfully",
+      "enrollmentRequested": "Enrollment request sent successfully"
+    },
     "failedToApprove": "Failed to approve enrollment",
     "failedToReject": "Failed to reject enrollment",
     "failedToUpdateCompetition": "Failed to update competition",
     "failedToDeleteCompetition": "Failed to delete competition",
     "failedToEnroll": "Failed to enroll",
-    "failedToLoadCompetitions": "Failed to load competitions"
+    "failedToLoadCompetitions": "Failed to load competitions",
+    "golfCourses": {
+      "title": "Golf Courses ({{count}})",
+      "addCourse": "Add Course",
+      "selectCourse": "Select Golf Course",
+      "noCourses": "No golf courses associated with this competition",
+      "errorLoading": "Failed to load golf courses",
+      "courseAdded": "Golf course added successfully",
+      "errorAdding": "Failed to add golf course",
+      "confirmRemove": "Are you sure you want to remove this golf course from the competition?",
+      "courseRemoved": "Golf course removed successfully",
+      "errorRemoving": "Failed to remove golf course",
+      "reordered": "Golf courses reordered successfully",
+      "errorReordering": "Failed to reorder golf courses",
+      "dragToReorder": "Drag to reorder courses",
+      "adding": "Adding course...",
+      "requestNotAvailable": "Requesting new courses is not available in this view. Use the competition creation page."
+    }
   },
   "browse": {
     "title": "Browse Competitions",
@@ -169,12 +211,12 @@
       "noOngoingCompetitions": "There are no closed, ongoing, or completed competitions at the moment"
     },
     "card": {
-      "createdBy": "Created by:",
+      "created-by": "Created by:",
       "players": "Players:",
       "full": "FULL",
       "requesting": "Requesting...",
-      "requestToJoin": "Request to Join",
-      "viewDetails": "View Details"
+      "request-to-join": "Request to Join",
+      "view-details": "View Details"
     },
     "errors": {
       "failedToLoadJoinable": "Failed to load available competitions",

--- a/src/i18n/locales/en/golfCourses.json
+++ b/src/i18n/locales/en/golfCourses.json
@@ -4,6 +4,7 @@
     "name": "Course Name",
     "namePlaceholder": "Pebble Beach Golf Links",
     "countryCode": "Country Code",
+    "selectCountry": "Select country...",
     "countryCodeHint": "ISO 3166-1 alpha-2 (e.g: ES, US, GB)",
     "courseType": "Course Type",
     "courseTypes": {

--- a/src/i18n/locales/es/competitions.json
+++ b/src/i18n/locales/es/competitions.json
@@ -22,7 +22,11 @@
     "pendingRequest": "solicitud pendiente",
     "pendingRequests": "solicitudes pendientes",
     "enrollmentStatus": "Inscripción: {{status}}",
-    "players": "{{count}} / {{max}} jugadores"
+    "players": "{{count}} / {{max}} jugadores",
+    "golfCoursesCount": "{{count}} campo",
+    "golfCoursesCount_plural": "{{count}} campos",
+    "countriesCount": "{{count}} país",
+    "countriesCount_plural": "{{count}} países"
   },
   "create": {
     "title": "Crear Competición",
@@ -79,7 +83,19 @@
       "playersMinimum": "El número de jugadores debe ser al menos 2",
       "playersMaximum": "El número de jugadores no puede exceder 100"
     },
-    "success": "¡Competición creada exitosamente!"
+    "success": "¡Competición creada exitosamente!",
+    "partialSuccess": "Competición creada, pero {{failed}} campo(s) no se pudieron añadir: {{courses}}. Se añadieron {{success}} campo(s) correctamente.",
+    "errorAddingCourses": "Competición creada, pero no se pudieron añadir los campos de golf. Puedes añadirlos manualmente desde la página de detalle.",
+    "error": "Error al crear la competición"
+  },
+  "edit": {
+    "title": "Editar Competición",
+    "loading": "Cargando competición...",
+    "updating": "Actualizando...",
+    "updateCompetition": "Actualizar Competición",
+    "success": "¡Competición actualizada exitosamente!",
+    "error": "Error al actualizar la competición",
+    "errorLoading": "Error al cargar la competición"
   },
   "detail": {
     "loadingCompetition": "Cargando competición...",
@@ -93,21 +109,21 @@
     "actions": {
       "edit": "Editar",
       "activate": "Activar",
-      "closeEnrollments": "Cerrar Inscripciones",
-      "startCompetition": "Iniciar Competición",
+      "close-enrollments": "Cerrar Inscripciones",
+      "start-competition": "Iniciar Competición",
       "complete": "Completar",
       "cancel": "Cancelar",
       "delete": "Eliminar",
-      "requestToJoin": "Solicitar Unirse"
+      "request-to-join": "Solicitar Unirse"
     },
     "confirmations": {
       "activate": "¿Estás seguro de que quieres activar esta competición?",
-      "closeEnrollments": "¿Estás seguro de que quieres cerrar las inscripciones de esta competición?",
+      "close-enrollments": "¿Estás seguro de que quieres cerrar las inscripciones de esta competición?",
       "start": "¿Estás seguro de que quieres iniciar esta competición?",
       "complete": "¿Estás seguro de que quieres completar esta competición?",
       "cancel": "¿Estás seguro de que quieres cancelar esta competición?",
       "delete": "¿Estás seguro de que quieres eliminar esta competición? Esta acción no se puede deshacer.",
-      "rejectEnrollment": "¿Estás seguro de que quieres rechazar esta inscripción?"
+      "reject-enrollment": "¿Estás seguro de que quieres rechazar esta inscripción?"
     },
     "errors": {
       "golfCoursePendingApproval": "No se puede activar la competición: El campo de golf está pendiente de aprobación",
@@ -139,12 +155,38 @@
     "rejected": "RECHAZADO",
     "enrollmentApproved": "Inscripción aprobada",
     "enrollmentRejected": "Inscripción rechazada",
+    "success": {
+      "activated": "Competición activada correctamente",
+      "enrollmentsClosed": "Inscripciones cerradas correctamente",
+      "started": "Competición iniciada correctamente",
+      "completed": "Competición completada correctamente",
+      "cancelled": "Competición cancelada correctamente",
+      "deleted": "Competición eliminada correctamente",
+      "enrollmentRequested": "Solicitud de inscripción enviada correctamente"
+    },
     "failedToApprove": "Error al aprobar la inscripción",
     "failedToReject": "Error al rechazar la inscripción",
     "failedToUpdateCompetition": "Error al actualizar la competición",
     "failedToDeleteCompetition": "Error al eliminar la competición",
     "failedToEnroll": "Error al solicitar inscripción",
-    "failedToLoadCompetitions": "Error al cargar las competiciones"
+    "failedToLoadCompetitions": "Error al cargar las competiciones",
+    "golfCourses": {
+      "title": "Campos de Golf ({{count}})",
+      "addCourse": "Añadir Campo",
+      "selectCourse": "Seleccionar Campo de Golf",
+      "noCourses": "No hay campos de golf asociados a esta competición",
+      "errorLoading": "Error al cargar los campos de golf",
+      "courseAdded": "Campo de golf añadido exitosamente",
+      "errorAdding": "Error al añadir el campo de golf",
+      "confirmRemove": "¿Estás seguro de que quieres eliminar este campo de golf de la competición?",
+      "courseRemoved": "Campo de golf eliminado exitosamente",
+      "errorRemoving": "Error al eliminar el campo de golf",
+      "reordered": "Campos de golf reordenados exitosamente",
+      "errorReordering": "Error al reordenar los campos de golf",
+      "dragToReorder": "Arrastra para reordenar los campos",
+      "adding": "Añadiendo campo...",
+      "requestNotAvailable": "La solicitud de nuevos campos no está disponible en esta vista. Usa la página de creación de competiciones."
+    }
   },
   "browse": {
     "title": "Explorar Competiciones",
@@ -169,12 +211,12 @@
       "noOngoingCompetitions": "No hay competiciones cerradas, en curso o completadas en este momento"
     },
     "card": {
-      "createdBy": "Creado por:",
+      "created-by": "Creado por:",
       "players": "Jugadores:",
       "full": "LLENO",
       "requesting": "Solicitando...",
-      "requestToJoin": "Solicitar Unirse",
-      "viewDetails": "Ver Detalles"
+      "request-to-join": "Solicitar Unirse",
+      "view-details": "Ver Detalles"
     },
     "errors": {
       "failedToLoadJoinable": "Error al cargar competiciones disponibles",

--- a/src/i18n/locales/es/golfCourses.json
+++ b/src/i18n/locales/es/golfCourses.json
@@ -4,6 +4,7 @@
     "name": "Nombre del Campo",
     "namePlaceholder": "Real Club de Golf El Prat",
     "countryCode": "Código de País",
+    "selectCountry": "Selecciona un país...",
     "countryCodeHint": "ISO 3166-1 alpha-2 (ej: ES, US, GB)",
     "courseType": "Tipo de Campo",
     "courseTypes": {

--- a/src/infrastructure/repositories/ApiCompetitionRepository.js
+++ b/src/infrastructure/repositories/ApiCompetitionRepository.js
@@ -136,6 +136,87 @@ class ApiCompetitionRepository extends ICompetitionRepository {
 
     return competitions;
   }
+
+  /**
+   * Adds a golf course to a competition.
+   * @override
+   * @param {string} competitionId - The ID of the competition.
+   * @param {string} golfCourseId - The ID of the golf course to add.
+   * @returns {Promise<object>} - The association details (competition_id, golf_course_id, display_order, added_at).
+   */
+  async addGolfCourse(competitionId, golfCourseId) {
+    const response = await apiRequest(`/api/v1/competitions/${competitionId}/golf-courses`, {
+      method: 'POST',
+      body: JSON.stringify({ golf_course_id: golfCourseId })
+    });
+
+    return response;
+  }
+
+  /**
+   * Removes a golf course from a competition.
+   * @override
+   * @param {string} competitionId - The ID of the competition.
+   * @param {string} golfCourseId - The ID of the golf course to remove.
+   * @returns {Promise<object>} - The removal confirmation (competition_id, golf_course_id, removed_at).
+   */
+  async removeGolfCourse(competitionId, golfCourseId) {
+    const response = await apiRequest(`/api/v1/competitions/${competitionId}/golf-courses/${golfCourseId}`, {
+      method: 'DELETE'
+    });
+
+    return response;
+  }
+
+  /**
+   * Reorders golf courses in a competition.
+   * @override
+   * @param {string} competitionId - The ID of the competition.
+   * @param {string[]} golfCourseIds - Array of golf course IDs in the new order.
+   * @returns {Promise<object>} - The reordered golf courses with display_order.
+   */
+  async reorderGolfCourses(competitionId, golfCourseIds) {
+    const response = await apiRequest(`/api/v1/competitions/${competitionId}/golf-courses/reorder`, {
+      method: 'PUT',
+      body: JSON.stringify({ golf_course_ids: golfCourseIds })
+    });
+
+    return response;
+  }
+
+  /**
+   * Gets all golf courses associated with a competition.
+   * @override
+   * @param {string} competitionId - The ID of the competition.
+   * @returns {Promise<object>} - Object containing competition_id and golf_courses array.
+   */
+  async getCompetitionGolfCourses(competitionId) {
+    const response = await apiRequest(`/api/v1/competitions/${competitionId}/golf-courses`);
+
+    return response;
+  }
+
+  /**
+   * Updates a competition.
+   * @override
+   * @param {string} competitionId - The ID of the competition to update.
+   * @param {object} competitionData - The updated competition data.
+   * @returns {Promise<Competition>} - The updated competition entity.
+   */
+  async updateCompetition(competitionId, competitionData) {
+    const apiData = await apiRequest(`/api/v1/competitions/${competitionId}`, {
+      method: 'PUT',
+      body: JSON.stringify(competitionData),
+    });
+
+    // Map API response to Competition domain entity
+    const competition = CompetitionMapper.toDomain(apiData);
+
+    // Attach original API data for mapper to use
+    competition._apiData = apiData;
+
+    return competition;
+  }
 }
 
 export default ApiCompetitionRepository;

--- a/src/infrastructure/repositories/ApiGolfCourseRepository.js
+++ b/src/infrastructure/repositories/ApiGolfCourseRepository.js
@@ -151,7 +151,7 @@ class ApiGolfCourseRepository extends IGolfCourseRepository {
    * @private
    */
   _mapToApiPayload(golfCourseData) {
-    return {
+    const payload = {
       name: golfCourseData.name,
       country_code: golfCourseData.countryCode || golfCourseData.country_code,
       course_type: golfCourseData.courseType || golfCourseData.course_type,
@@ -167,6 +167,8 @@ class ApiGolfCourseRepository extends IGolfCourseRepository {
         stroke_index: hole.strokeIndex || hole.stroke_index,
       })),
     };
+
+    return payload;
   }
 }
 

--- a/src/pages/BrowseCompetitions.jsx
+++ b/src/pages/BrowseCompetitions.jsx
@@ -471,7 +471,7 @@ const CompetitionCard = ({ competition, mode, onRequestEnrollment, onViewDetails
         <div className="flex items-center text-sm text-gray-600">
           <Users className="w-4 h-4 mr-2 text-gray-400" />
           <span>
-            {t('browse.card.createdBy')} <span className="font-medium text-gray-900">{creator?.firstName} {creator?.lastName}</span>
+            {t('browse.card.created-by')} <span className="font-medium text-gray-900">{creator?.firstName} {creator?.lastName}</span>
           </span>
         </div>
 
@@ -504,7 +504,7 @@ const CompetitionCard = ({ competition, mode, onRequestEnrollment, onViewDetails
         {(() => {
           if (isRequesting) return t('browse.card.requesting');
           if (enrolledCount >= maxPlayers) return t('browse.card.full');
-          return t('browse.card.requestToJoin');
+          return t('browse.card.request-to-join');
         })()}
       </button>
         ) : (
@@ -515,7 +515,7 @@ const CompetitionCard = ({ competition, mode, onRequestEnrollment, onViewDetails
             }}
             className="w-full py-2 px-4 rounded-lg font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition"
           >
-            {t('browse.card.viewDetails')}
+            {t('browse.card.view-details')}
           </button>
         )}
       </div>

--- a/src/pages/Competitions.jsx
+++ b/src/pages/Competitions.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import {
   Users, Calendar, MapPin, Plus,
-  Filter, Search, AlertCircle, Loader, Crown
+  Filter, Search, AlertCircle, Loader, Crown, Flag
 } from 'lucide-react';
 import customToast from '../utils/toast';
 import { useTranslation } from 'react-i18next';
@@ -14,6 +14,7 @@ import {
   formatDateRange
 } from '../services/competitions';
 import { isDeviceRevoked, handleDeviceRevocationLogout } from '../utils/deviceRevocationLogout';
+import { CountryFlag } from '../utils/countryUtils';
 
 // Helper function to get enrollment status classes
 const getEnrollmentStatusClasses = (status) => {
@@ -250,6 +251,38 @@ const Competitions = () => {
                   {t('myCompetitions.players', { count: competition.enrolledCount || 0, max: competition.maxPlayers })}
                 </span>
               </div>
+
+              {/* Golf Courses / Countries */}
+              {competition.countries && competition.countries.length > 0 && (
+                <div className="flex items-center gap-2 text-gray-600 text-sm">
+                  <Flag className="w-4 h-4" />
+                  <div className="flex items-center gap-1.5">
+                    {/* Show country flags */}
+                    {competition.countries.slice(0, 3).map((country, index) => (
+                      <CountryFlag
+                        key={country.code || index}
+                        countryCode={country.code}
+                        style={{ width: '20px', height: 'auto' }}
+                        title={country.name || country.nameEn || country.code}
+                      />
+                    ))}
+                    {/* Show count text only if golf_courses_count is available */}
+                    {competition.golf_courses_count !== undefined && competition.golf_courses_count > 0 && (
+                      <span className="ml-1">
+                        {competition.golf_courses_count === 1
+                          ? t('myCompetitions.golfCoursesCount', { count: competition.golf_courses_count })
+                          : t('myCompetitions.golfCoursesCount_plural', { count: competition.golf_courses_count })}
+                      </span>
+                    )}
+                    {/* Show +N if more than 3 countries */}
+                    {competition.countries.length > 3 && (
+                      <span className="text-xs text-gray-500">
+                        +{competition.countries.length - 3}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              )}
             </div>
           </motion.div>
         ))}

--- a/src/pages/admin/PendingGolfCourses.jsx
+++ b/src/pages/admin/PendingGolfCourses.jsx
@@ -1,17 +1,21 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { Loader } from 'lucide-react';
+import { Loader, X, Flag, MapPin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import customToast from '../../utils/toast';
 import HeaderAuth from '../../components/layout/HeaderAuth';
 import { useAuth } from '../../hooks/useAuth';
 import GolfCourseTable from '../../components/golf_course/GolfCourseTable';
+import TeeCategoryBadge from '../../components/golf_course/TeeCategoryBadge';
+import { CountryFlag } from '../../utils/countryUtils';
+import { formatCountryName } from '../../services/countries';
 import {
   listPendingGolfCoursesUseCase,
   approveGolfCourseUseCase,
   rejectGolfCourseUseCase,
   approveGolfCourseUpdateUseCase,
   rejectGolfCourseUpdateUseCase,
+  fetchCountriesUseCase,
 } from '../../composition';
 
 /**
@@ -20,7 +24,7 @@ import {
  * Two tabs: New Requests + Update Proposals
  */
 const PendingGolfCourses = () => {
-  const { t } = useTranslation('golfCourses');
+  const { t, i18n } = useTranslation('golfCourses');
   const { user, loading: isLoadingUser } = useAuth();
 
   const [pendingCourses, setPendingCourses] = useState([]);
@@ -29,6 +33,9 @@ const PendingGolfCourses = () => {
   const [showRejectModal, setShowRejectModal] = useState(false);
   const [rejectReason, setRejectReason] = useState('');
   const [courseToReject, setCourseToReject] = useState(null);
+  const [showDetailsModal, setShowDetailsModal] = useState(false);
+  const [courseToView, setCourseToView] = useState(null);
+  const [allCountries, setAllCountries] = useState([]);
 
   // Derive isAdmin from authenticated user's roles
   const isAdmin = user?.roles?.some(role =>
@@ -48,6 +55,19 @@ const PendingGolfCourses = () => {
       setIsLoading(false);
     }
   };
+
+  // Load countries for details modal
+  useEffect(() => {
+    const fetchCountries = async () => {
+      try {
+        const data = await fetchCountriesUseCase.execute();
+        setAllCountries(data || []);
+      } catch (error) {
+        console.error('Error fetching countries:', error);
+      }
+    };
+    fetchCountries();
+  }, []);
 
   useEffect(() => {
     if (user) {
@@ -74,6 +94,12 @@ const PendingGolfCourses = () => {
       console.error('Error approving golf course:', error);
       customToast.error(error.message || t('pages.pending.approveFailed'));
     }
+  };
+
+  // Handle view details
+  const handleViewDetails = (course) => {
+    setCourseToView(course);
+    setShowDetailsModal(true);
   };
 
   // Handle reject new request
@@ -238,6 +264,7 @@ const PendingGolfCourses = () => {
               <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
                 <GolfCourseTable
                   courses={currentCourses}
+                  onView={handleViewDetails}
                   onApprove={activeTab === 'new' ? handleApproveNew : handleApproveUpdate}
                   onReject={activeTab === 'new' ? handleRejectNew : handleRejectUpdate}
                   isAdmin={isAdmin}
@@ -248,6 +275,132 @@ const PendingGolfCourses = () => {
           </div>
         </div>
       </div>
+
+      {/* Details Modal */}
+      {showDetailsModal && courseToView && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4 overflow-y-auto">
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            className="bg-white rounded-xl shadow-2xl max-w-4xl w-full my-8"
+          >
+            {/* Header */}
+            <div className="p-6 border-b border-gray-200 flex items-center justify-between">
+              <div>
+                <h2 className="text-2xl font-bold text-gray-900">{courseToView.name}</h2>
+                <div className="flex items-center gap-2 mt-1">
+                  <CountryFlag countryCode={courseToView.countryCode} style={{ width: '20px', height: 'auto' }} />
+                  <span className="text-sm text-gray-600">
+                    {formatCountryName(
+                      allCountries.find(c => c.code === courseToView.countryCode) || { name_en: courseToView.countryCode },
+                      i18n.language
+                    )}
+                  </span>
+                </div>
+              </div>
+              <button
+                onClick={() => setShowDetailsModal(false)}
+                className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            {/* Content */}
+            <div className="p-6 space-y-6 max-h-[70vh] overflow-y-auto">
+              {/* Basic Info */}
+              <div>
+                <h3 className="text-lg font-bold text-gray-900 mb-3 flex items-center gap-2">
+                  <MapPin className="w-5 h-5 text-primary" />
+                  {t('form.basicInfo')}
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div className="bg-gray-50 rounded-lg p-4">
+                    <p className="text-xs text-gray-600 mb-1">{t('table.type')}</p>
+                    <p className="font-semibold text-gray-900">{t(`form.courseTypes.${courseToView.courseType}`)}</p>
+                  </div>
+                  <div className="bg-gray-50 rounded-lg p-4">
+                    <p className="text-xs text-gray-600 mb-1">{t('table.par')}</p>
+                    <p className="font-semibold text-gray-900">{courseToView.totalPar}</p>
+                  </div>
+                  <div className="bg-gray-50 rounded-lg p-4">
+                    <p className="text-xs text-gray-600 mb-1">{t('table.tees')}</p>
+                    <p className="font-semibold text-gray-900">{courseToView?.tees?.length ?? 0}</p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Tees */}
+              <div>
+                <h3 className="text-lg font-bold text-gray-900 mb-3 flex items-center gap-2">
+                  <Flag className="w-5 h-5 text-primary" />
+                  {t('form.tees')} ({courseToView?.tees?.length ?? 0})
+                </h3>
+                <div className="space-y-3">
+                  {(courseToView?.tees || []).map((tee, index) => (
+                    <div key={index} className="bg-gray-50 rounded-lg p-4">
+                      <div className="flex items-center justify-between mb-2">
+                        <TeeCategoryBadge category={tee.teeCategory} identifier={tee.identifier} />
+                        <span className="text-sm text-gray-600">{t('form.tee')} {index + 1}</span>
+                      </div>
+                      <div className="grid grid-cols-2 gap-4 mt-3">
+                        <div>
+                          <p className="text-xs text-gray-600">{t('form.courseRating')}</p>
+                          <p className="font-medium text-gray-900">{tee.courseRating}</p>
+                        </div>
+                        <div>
+                          <p className="text-xs text-gray-600">{t('form.slopeRating')}</p>
+                          <p className="font-medium text-gray-900">{tee.slopeRating}</p>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Holes */}
+              <div>
+                <h3 className="text-lg font-bold text-gray-900 mb-3">{t('form.holes')}</h3>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead className="bg-gray-100 border-b border-gray-200">
+                      <tr>
+                        <th className="text-center py-2 px-3 font-semibold text-gray-700">{t('form.hole')}</th>
+                        <th className="text-center py-2 px-3 font-semibold text-gray-700">{t('form.par')}</th>
+                        <th className="text-center py-2 px-3 font-semibold text-gray-700">{t('form.strokeIndex')}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {(courseToView?.holes || []).map((hole, index) => (
+                        <tr key={index} className="border-b border-gray-100">
+                          <td className="text-center py-2 px-3 font-medium text-gray-900">{hole.holeNumber}</td>
+                          <td className="text-center py-2 px-3 text-gray-700">{hole.par}</td>
+                          <td className="text-center py-2 px-3 text-gray-700">{hole.strokeIndex}</td>
+                        </tr>
+                      ))}
+                      <tr className="bg-gray-50 font-bold">
+                        <td className="text-center py-2 px-3 text-gray-900">{t('form.totalPar')}</td>
+                        <td className="text-center py-2 px-3 text-gray-900">{courseToView.totalPar}</td>
+                        <td className="text-center py-2 px-3"></td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+
+            {/* Footer */}
+            <div className="p-6 border-t border-gray-200 flex items-center justify-end gap-3">
+              <button
+                onClick={() => setShowDetailsModal(false)}
+                className="px-6 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50"
+              >
+                {t('pages.pending.close', 'Close')}
+              </button>
+            </div>
+          </motion.div>
+        </div>
+      )}
 
       {/* Reject Modal */}
       {showRejectModal && courseToReject && (

--- a/src/services/countries.js
+++ b/src/services/countries.js
@@ -212,12 +212,21 @@ export const getAdjacentCountriesFallback = (countryCode) => {
 /**
  * Format country name based on user's language preference
  * @param {object} country - Country object with name_en and name_es
- * @param {string} language - 'en' or 'es'
+ * @param {string} language - 'en', 'es', 'en-US', 'es-ES', etc.
  * @returns {string}
  */
 export const formatCountryName = (country, language = 'en') => {
   if (!country) return '';
-  return language === 'es' ? (country.name_es || country.name_en || country.name) : (country.name_en || country.name);
+
+  // Normalize language to base code (es-ES -> es, en-US -> en)
+  const baseLang = language ? language.toLowerCase().split('-')[0] : 'en';
+
+  // Always prefer the requested language, fallback to the other language
+  if (baseLang === 'es') {
+    return country.name_es || country.name_en || country.name || '';
+  }
+
+  return country.name_en || country.name_es || country.name || '';
 };
 
 /**


### PR DESCRIPTION
## 🚀 Release v2.0.2

This release adds complete competition editing functionality and comprehensive golf course management within competitions.

### 📦 Main Features

#### 1. Competition Edit Workflow
- ✅ New route `/competitions/:id/edit` for editing existing competitions
- ✅ `UpdateCompetitionUseCase` with full validation and Invalid Date checks
- ✅ Pre-loading of existing competition data
- ✅ Field name mapping fixes (`team_1_name` vs `team_one_name`)

#### 2. Golf Course Management in Competitions
- ✅ **Add golf courses** to competitions via search and selection
- ✅ **Remove golf courses** from competitions with confirmation
- ✅ **Reorder golf courses** using drag & drop (@dnd-kit integration)
- ✅ **View golf course details** modal in admin pending approvals
- ✅ New use cases:
  - `AddGolfCourseToCompetitionUseCase`
  - `RemoveGolfCourseFromCompetitionUseCase`
  - `ReorderGolfCoursesUseCase`
  - `GetCompetitionGolfCoursesUseCase`

#### 3. UI/UX Improvements
- ✅ `CompetitionGolfCoursesSection` component with full CRUD operations
- ✅ Golf course details modal with tees, holes, and approval status
- ✅ Enhanced golf course presentation with colored badges (country, type, par)
- ✅ Golf course count and country flags display in competition cards
- ✅ Improved competition card layout showing associated courses

#### 4. Defensive Programming & Code Quality
- ✅ Invalid Date validation in `UpdateCompetitionUseCase` (isNaN checks)
- ✅ Defensive null checks in `PendingGolfCourses` for tees/holes arrays
- ✅ Safe error logging replacing JSON.stringify (prevents circular ref errors)
- ✅ Optional chaining and fallback arrays to prevent runtime errors

#### 5. i18n Standardization
- ✅ Refactored all multi-word translation keys to kebab-case
- ✅ Following i18next standard convention
- ✅ Keys updated:
  - `detail.actions`: `closeEnrollments` → `close-enrollments`, `startCompetition` → `start-competition`, `requestToJoin` → `request-to-join`
  - `detail.confirmations`: `rejectEnrollment` → `reject-enrollment`
  - `browse.card`: `createdBy` → `created-by`, `requestToJoin` → `request-to-join`, `viewDetails` → `view-details`
- ✅ Complete Spanish/English translations consistency

#### 6. Permissions & Access Control
- ✅ Fixed admin enrollment logic: admins can both manage AND enroll in competitions
- ✅ Corrected `RoleGuard` to allow global admins full access

### 📊 Statistics

**Files changed:** 28 files, 1425 insertions(+), 107 deletions(-)

**New dependencies:**
- `@dnd-kit/core` (^6.3.1)
- `@dnd-kit/sortable` (^9.0.0)
- `@dnd-kit/utilities` (^3.2.2)

**API Integration:**
- `POST /api/v1/competitions/:id/golf-courses`
- `DELETE /api/v1/competitions/:id/golf-courses/:courseId`
- `PUT /api/v1/competitions/:id/golf-courses/reorder`
- `GET /api/v1/competitions/:id/golf-courses`
- `PUT /api/v1/competitions/:id`

### ✅ Quality Assurance

- ✅ **ESLint:** 0 errors, 0 warnings
- ✅ **Tests:** 843 passed, 1 skipped
- ✅ **Coverage:** Lines 81.37%, Statements 81.1%, Functions 82.53%, Branches 78.33%
- ✅ **Build:** Successful (1473 KB, under 1500 KB limit)
- ✅ **Clean Architecture:** Domain, Application, Infrastructure, Presentation layers maintained
- ✅ **All commits GPG signed**

### 🔗 Related PRs

- #111 - Feature/sprint-2-schedule-matches

### 📝 Changelog

See [CHANGELOG.md](./CHANGELOG.md) for detailed changes.

### 🎯 Next Steps

Sprint 2 continues with:
- Schedule drag-and-drop functionality
- Match creation wizard
- Match detail modal
- Manual match status control
- Walkover functionality

---

**Sync Point:** Viernes 14 Feb 2026  
**Version:** v2.0.2  
**Sprint:** Sprint 2 (En Curso)

🤖 Generated with [Claude Code](https://claude.com/claude-code)