### PR TITLE
fix(UI): Hotfix v2.0.6: Fix tee badge colors and show all tees

### DIFF
--- a/src/components/golf_course/GolfCourseTable.jsx
+++ b/src/components/golf_course/GolfCourseTable.jsx
@@ -88,12 +88,9 @@ const GolfCourseTable = ({ courses, onView, onEdit, onApprove, onReject, showAct
               <td className="py-3 px-4 font-medium text-gray-900">{course.totalPar}</td>
               <td className="py-3 px-4">
                 <div className="flex flex-wrap gap-1">
-                  {course.tees.slice(0, 2).map((tee, index) => (
+                  {course.tees.map((tee, index) => (
                     <TeeCategoryBadge key={index} category={tee.teeCategory} identifier={tee.identifier} gender={tee.teeGender || tee.tee_gender || tee.gender} />
                   ))}
-                  {course.tees.length > 2 && (
-                    <span className="text-xs text-gray-500">+{course.tees.length - 2}</span>
-                  )}
                 </div>
               </td>
               <td className="py-3 px-4">

--- a/src/components/golf_course/TeeCategoryBadge.jsx
+++ b/src/components/golf_course/TeeCategoryBadge.jsx
@@ -10,30 +10,27 @@ const TeeCategoryBadge = ({ category, identifier, gender }) => {
   const getCategoryColor = (cat) => {
     switch (cat) {
       case 'CHAMPIONSHIP':
-        return 'bg-black text-white border-black';
+        return 'bg-white text-gray-800 border-gray-300';
       case 'AMATEUR':
-        return 'bg-blue-100 text-blue-800 border-blue-200';
-      case 'SENIOR':
-        return 'bg-green-100 text-green-800 border-green-200';
-      case 'FORWARD':
-        return 'bg-pink-100 text-pink-800 border-pink-200';
-      case 'JUNIOR':
         return 'bg-yellow-100 text-yellow-800 border-yellow-200';
+      case 'SENIOR':
+        return 'bg-blue-100 text-blue-800 border-blue-200';
+      case 'FORWARD':
+        return 'bg-red-100 text-red-800 border-red-200';
+      case 'JUNIOR':
+        return 'bg-orange-100 text-orange-800 border-orange-200';
       default:
         return 'bg-gray-100 text-gray-800 border-gray-200';
     }
   };
 
   const colorClass = getCategoryColor(category);
-  const categoryLabel = t(`form.teeCategories.${category}`, { defaultValue: category });
-  const genderLabel = gender ? ` (${t(`form.teeGenders.${gender}`, { defaultValue: gender })})` : '';
+  const label = identifier || t(`form.teeCategories.${category}`, { defaultValue: category });
+  const genderSuffix = gender === 'MALE' ? ' (M)' : gender === 'FEMALE' ? ' (F)' : '';
 
   return (
-    <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold border ${colorClass}`}>
-      {identifier && (
-        <span className="font-bold">{identifier}</span>
-      )}
-      <span>{categoryLabel}{genderLabel}</span>
+    <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold border ${colorClass}`}>
+      {label}{genderSuffix}
     </span>
   );
 };


### PR DESCRIPTION
## Summary
- Tee category badge colors corrected to match standard golf conventions: Championship (white), Amateur (yellow), Senior (blue), Forward (red), Junior (orange)
- Badge now displays the tee identifier name instead of the internal category type, with gender suffix (M/F) when present
- Removed tee list truncation in golf course table — all tees are now visible

## Test plan
- [x] All 1087 tests passing, 1 skipped
- [x] ESLint clean
- [x] Production build successful
- [ ] Verify tee badge colors on admin golf courses page
- [ ] Verify all tees display (no "+N" truncation)
- [ ] Verify identifier name shows instead of category type
- [ ] Verify gender suffix (M)/(F) appears when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)