### PR TITLE
fix(deps): Upgrade vite 7.3.1 → 7.3.2 to patch 3 High CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7430,9 +7430,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

`vite` 7.3.1 → 7.3.2 via `npm audit fix`. Three new High severity CVEs published after previous hotfix:

- **GHSA-4w7w-66w2-5vf9** (High): Path traversal in optimized deps `.map` handling
- **GHSA-v2wj-q39q-566r** (High): `server.fs.deny` bypassed with queries
- **GHSA-p9ff-h696-f583** (High): Arbitrary file read via Vite dev server WebSocket

Only `package-lock.json` changed — `^7.3.0` range in `package.json` already covers 7.3.2.

## Test plan

- [x] 1559 tests passing locally (130 suites)
- [x] Production build successful (Vite 7.3.2)
- [x] `npm audit` → 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)