### PR TITLE
fix: SW cache, same-day dates, 422 errors, and match summary winner

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -62,6 +62,26 @@ server {
     }
 
     # ==========================================
+    # PWA - SERVICE WORKER Y MANIFEST - Nunca cachear
+    # ==========================================
+    # Sin esto, /sw.js cae en el bloque de assets estáticos de abajo (matchea \.js$)
+    # y el navegador lo cachea 1 año como immutable. Con registerType: autoUpdate,
+    # el SW viejo queda servido desde cache HTTP y su manifest de precache referencia
+    # chunks con hash que el siguiente deploy ya borró del dist -> 404 en el install
+    # del SW -> register() rechaza sin catch (ver Sentry #132442519).
+    # location = tiene prioridad sobre el regex de abajo sin importar el orden.
+    location = /sw.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Service-Worker-Allowed "/";
+        access_log off;
+    }
+
+    location = /manifest.webmanifest {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        access_log off;
+    }
+
+    # ==========================================
     # STATIC ASSETS - Cache agresivo
     # ==========================================
     # Archivos JS, CSS, imágenes, fuentes

--- a/src/application/use_cases/competition/UpdateCompetitionUseCase.js
+++ b/src/application/use_cases/competition/UpdateCompetitionUseCase.js
@@ -77,8 +77,8 @@ class UpdateCompetitionUseCase {
       throw new Error('Invalid end_date');
     }
 
-    if (endDate <= startDate) {
-      throw new Error('End date must be after start date');
+    if (endDate < startDate) {
+      throw new Error('End date must be on or after start date');
     }
 
     // Call repository (backend validates business rules like ownership and status)

--- a/src/components/scoring/MatchSummaryCard.jsx
+++ b/src/components/scoring/MatchSummaryCard.jsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
-const MatchSummaryCard = ({ summary }) => {
+const MatchSummaryCard = ({ summary, winnerName }) => {
   const { t } = useTranslation('scoring');
 
   if (!summary) return null;
@@ -15,11 +15,13 @@ const MatchSummaryCard = ({ summary }) => {
           <p className="text-3xl font-bold text-primary mt-1">
             {summary.result.score}
           </p>
-          {summary.result.winner && (
+          {summary.result.winner === 'HALVED' ? (
+            <p className="text-sm text-gray-600 mt-1">{t('summary.halved')}</p>
+          ) : winnerName ? (
             <p className="text-sm text-gray-600 mt-1">
-              {t('summary.winner')}: {summary.result.winner}
+              {t('summary.winner')}: {winnerName}
             </p>
-          )}
+          ) : null}
         </div>
       )}
 

--- a/src/components/scoring/MatchSummaryCard.test.jsx
+++ b/src/components/scoring/MatchSummaryCard.test.jsx
@@ -50,4 +50,22 @@ describe('MatchSummaryCard', () => {
     render(<MatchSummaryCard summary={mockSummary} />);
     expect(screen.getByTestId('match-summary-card')).toHaveTextContent('summary.matchComplete');
   });
+
+  it('should display the resolved winner name when provided', () => {
+    render(<MatchSummaryCard summary={mockSummary} winnerName="Team A (John Doe)" />);
+    expect(screen.getByTestId('match-summary-card')).toHaveTextContent('Team A (John Doe)');
+  });
+
+  it('should not display a winner line when winnerName is not provided', () => {
+    render(<MatchSummaryCard summary={mockSummary} />);
+    expect(screen.getByTestId('match-summary-card')).not.toHaveTextContent('summary.winner');
+  });
+
+  it('should show the halved message instead of a winner name for a tied match', () => {
+    const halvedSummary = { ...mockSummary, result: { winner: 'HALVED', score: 'AS' } };
+    render(<MatchSummaryCard summary={halvedSummary} winnerName="Team A (John Doe)" />);
+    const card = screen.getByTestId('match-summary-card');
+    expect(card).toHaveTextContent('summary.halved');
+    expect(card).not.toHaveTextContent('John Doe');
+  });
 });

--- a/src/i18n/locales/en/scoring.json
+++ b/src/i18n/locales/en/scoring.json
@@ -112,6 +112,7 @@
     "holesWon": "Holes Won",
     "holesLost": "Holes Lost",
     "holesHalved": "Holes Halved",
+    "halved": "Match Halved",
     "matchComplete": "Match Complete",
     "waitingForOthers": "Waiting for other players to submit",
     "backToSchedule": "Back to Schedule",

--- a/src/i18n/locales/es/scoring.json
+++ b/src/i18n/locales/es/scoring.json
@@ -112,6 +112,7 @@
     "holesWon": "Hoyos Ganados",
     "holesLost": "Hoyos Perdidos",
     "holesHalved": "Hoyos Empatados",
+    "halved": "Partido Empatado",
     "matchComplete": "Partido Completado",
     "waitingForOthers": "Esperando a que los demás jugadores envíen su tarjeta",
     "backToSchedule": "Volver al Calendario",

--- a/src/index.css
+++ b/src/index.css
@@ -159,3 +159,14 @@
 @utility border-primary {
   border-color: var(--color-primary-500);
 }
+
+/* Sentry feedback widget ("Report a Bug") defaults to bottom-right, which
+   overlaps our react-hot-toast notifications and bottom banners. The widget
+   renders in a shadow DOM host (#sentry-feedback) that only reads CSS custom
+   properties, so it can't be restyled with normal selectors — moving it means
+   overriding --actor-inset (top/right/bottom/left) from outside the shadow
+   root. Left untouched: --dialog-inset, so the report form itself still opens
+   in its default position. */
+#sentry-feedback {
+  --actor-inset: auto auto 0 0;
+}

--- a/src/pages/player/ScoringPage.jsx
+++ b/src/pages/player/ScoringPage.jsx
@@ -202,11 +202,24 @@ const ScoringPage = () => {
 
   // Match summary screen
   if (matchSummary) {
+    const winnerTeam = matchSummary.result?.winner;
+    const winnerTeamName = winnerTeam === 'A'
+      ? scoringView?.teamAName
+      : winnerTeam === 'B'
+        ? scoringView?.teamBName
+        : null;
+    const winnerPlayerNames = (winnerTeam === 'A' || winnerTeam === 'B')
+      ? scoringView?.players?.filter((p) => p.team === winnerTeam).map((p) => p.userName).join(' y ')
+      : null;
+    const winnerName = winnerTeamName && winnerPlayerNames
+      ? `${winnerTeamName} (${winnerPlayerNames})`
+      : winnerTeamName;
+
     return (
       <div className="min-h-screen bg-gray-50">
         <HeaderAuth user={user} />
         <div className="max-w-lg mx-auto px-4 py-6">
-          <MatchSummaryCard summary={matchSummary} />
+          <MatchSummaryCard summary={matchSummary} winnerName={winnerName} />
           <button
             onClick={() => navigate(-1)}
             className="mt-4 w-full px-4 py-2 bg-gray-100 text-gray-700 rounded-lg font-medium hover:bg-gray-200"

--- a/src/pages/player/ScoringPage.test.jsx
+++ b/src/pages/player/ScoringPage.test.jsx
@@ -97,7 +97,9 @@ vi.mock('../../components/scoring/PreMatchInfo', () => ({
   default: () => <div data-testid="pre-match-info">PreMatchInfo</div>,
 }));
 vi.mock('../../components/scoring/MatchSummaryCard', () => ({
-  default: () => <div data-testid="match-summary-card">MatchSummaryCard</div>,
+  default: ({ winnerName }) => (
+    <div data-testid="match-summary-card">MatchSummaryCard {winnerName}</div>
+  ),
 }));
 vi.mock('../../components/scoring/OfflineBanner', () => ({
   default: () => <div data-testid="offline-banner">OfflineBanner</div>,
@@ -178,5 +180,34 @@ describe('ScoringPage', () => {
     render(<ScoringPage />);
     expect(screen.getByText('input.prevHole')).toBeInTheDocument();
     expect(screen.getByText('input.nextHole')).toBeInTheDocument();
+  });
+
+  describe('match summary screen', () => {
+    afterEach(() => {
+      mockUseScoring.matchSummary = null;
+    });
+
+    it('should resolve the winning team and player names', () => {
+      mockUseScoring.matchSummary = {
+        matchId: 'm-1',
+        result: { winner: 'A', score: '3&2' },
+        stats: { playerGrossTotal: 82, playerNetTotal: 72, holesWon: 8, holesLost: 5 },
+        matchComplete: false,
+      };
+      render(<ScoringPage />);
+      expect(screen.getByTestId('match-summary-card')).toHaveTextContent('Europe (Player A)');
+    });
+
+    it('should pass no winner name for a halved match', () => {
+      mockUseScoring.matchSummary = {
+        matchId: 'm-1',
+        result: { winner: 'HALVED', score: 'AS' },
+        stats: { playerGrossTotal: 82, playerNetTotal: 82, holesWon: 6, holesLost: 6 },
+        matchComplete: false,
+      };
+      render(<ScoringPage />);
+      expect(screen.getByTestId('match-summary-card')).not.toHaveTextContent('Europe');
+      expect(screen.getByTestId('match-summary-card')).not.toHaveTextContent('USA');
+    });
   });
 });

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -85,10 +85,19 @@ export const apiRequest = async (endpoint, options = {}) => {
       let errorMessage = '';
 
       if (errorData.detail) {
-        // FastAPI returns errors in 'detail' field
-        errorMessage = typeof errorData.detail === 'string'
-          ? errorData.detail
-          : JSON.stringify(errorData.detail);
+        // FastAPI returns errors in 'detail' field. On 422s it's a list of
+        // Pydantic error objects ({ type, loc, msg, input, ctx }) rather than
+        // a string — extract `msg` from each so the user sees readable text
+        // instead of the raw JSON blob.
+        if (typeof errorData.detail === 'string') {
+          errorMessage = errorData.detail;
+        } else if (Array.isArray(errorData.detail)) {
+          errorMessage = errorData.detail
+            .map((err) => err?.msg || JSON.stringify(err))
+            .join('; ');
+        } else {
+          errorMessage = JSON.stringify(errorData.detail);
+        }
       } else if (errorData.message) {
         // Some APIs use 'message' field
         errorMessage = errorData.message;


### PR DESCRIPTION
## Summary
- Prevent stale service worker after deploy: `/sw.js` and `/manifest.webmanifest` were falling into the 1-year immutable cache block for static assets, so a stale SW's precache manifest referenced chunks removed by the next deploy, causing `register()` to reject.
- Allow `end_date == start_date` when creating/updating a competition (frontend counterpart to the backend same-day dates fix).
- Reposition the Sentry "Report a Bug" feedback widget so it doesn't overlap toast notifications and bottom banners.
- Extract readable messages from FastAPI 422 validation error responses (`detail` is a list of Pydantic error objects, not a string) instead of showing raw JSON to the user.
- Show the resolved winner name (team + player names, e.g. "Europe (John Doe)") in the match summary screen instead of the raw "A"/"B" code, and a dedicated message for halved matches. Backend counterpart makes this result available before every player submits their own scorecard.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test -- --run` — 1608 passing, 1 skipped
- [x] Manual review of nginx cache header behavior for `/sw.js` and `/manifest.webmanifest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)