### PR TITLE
chore(release): PREPARE RELEASE V2.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [2.0.18] - 2026-07-07
+
+### Fixed
+
+**PWA — Stale Service Worker After Deploy**
+
+- `/sw.js` and `/manifest.webmanifest` fell into the aggressive 1-year immutable cache block for static assets (matched `\.js$`), so browsers cached the old service worker after a deploy. With `registerType: autoUpdate`, the stale SW's precache manifest then referenced hashed chunks the next deploy had already removed from `dist`, causing a 404 during install and `register()` to reject without a catch handler. Nginx cache headers updated to exclude these files.
+
+**Competition — Same-Day Start and End Dates**
+
+- Frontend counterpart to the backend date range fix: single-day tournaments (`start_date == end_date`) are now accepted instead of rejected as invalid.
+
+**UI — Sentry Feedback Widget Overlapping Toasts**
+
+- The "Report a Bug" widget defaulted to bottom-right, overlapping `react-hot-toast` notifications and bottom banners. It renders in a shadow DOM host that only reads CSS custom properties, so it's repositioned by overriding `--actor-inset` from outside the shadow root.
+
+**API — Unreadable FastAPI 422 Validation Errors**
+
+- On 422 responses, `errorData.detail` is a list of Pydantic error objects (`{type, loc, msg, input, ctx}`) rather than a string, so it was shown to the user as a raw JSON blob. Each error's `msg` is now extracted and joined into a readable message.
+
+**Scoring — Match Summary Winner Shown as Raw Team Code**
+
+- `MatchSummaryCard` displayed the raw team code ("A"/"B") returned by the backend instead of a readable name. `ScoringPage` now resolves it to the team name plus its players (e.g. "Europe (John Doe)") using data already available from the scoring view, and a halved match shows a dedicated message instead of the literal "HALVED" string.
+
+---
+
 ## [2.0.17] - 2026-07-06
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # 🗺️ Roadmap - RyderCupFriends Frontend
 
-> **Version:** 1.15.0 → 1.16.0 → 2.0.0 → 2.0.4 → 2.0.5 → 2.0.6 → 2.0.9 → 2.0.10 → 2.0.11 → 2.0.12 → 2.0.17 (synchronized with backend)
-> **Last Update:** Jul 6, 2026
-> **Status:** ✅ v2.0.0 Sprint 1 Completed | ✅ v2.0.4 Sprint 2 + Infra Completed | ✅ v2.0.5 Hotfix UI | ✅ v2.0.6 Sprint 2 Schedule COMPLETED | ✅ v2.0.9 Clean Architecture | ✅ v2.0.10 Manual Pairings | ✅ v2.0.11 Sprint 3 Invitations | ✅ v2.0.12 Sprint 4 Live Scoring COMPLETE | ✅ v2.0.13 Sprint 5 Absorbed + Post-Sprint 4 | ✅ v2.0.14 Build/CI Dependencies | ✅ v2.0.15 TeeCategory VO + Security Hotfixes | ✅ v2.0.17 Scoring Improvements
+> **Version:** 1.15.0 → 1.16.0 → 2.0.0 → 2.0.4 → 2.0.5 → 2.0.6 → 2.0.9 → 2.0.10 → 2.0.11 → 2.0.12 → 2.0.17 → 2.0.18 (synchronized with backend)
+> **Last Update:** Jul 7, 2026
+> **Status:** ✅ v2.0.0 Sprint 1 Completed | ✅ v2.0.4 Sprint 2 + Infra Completed | ✅ v2.0.5 Hotfix UI | ✅ v2.0.6 Sprint 2 Schedule COMPLETED | ✅ v2.0.9 Clean Architecture | ✅ v2.0.10 Manual Pairings | ✅ v2.0.11 Sprint 3 Invitations | ✅ v2.0.12 Sprint 4 Live Scoring COMPLETE | ✅ v2.0.13 Sprint 5 Absorbed + Post-Sprint 4 | ✅ v2.0.14 Build/CI Dependencies | ✅ v2.0.15 TeeCategory VO + Security Hotfixes | ✅ v2.0.17 Scoring Improvements | ✅ v2.0.18 Hotfix (SW cache, dates, 422 errors, match summary)
 > **Stack:** React 19 + Vite 7.3 + Tailwind CSS 4 + ESLint 9
 > **Architecture:** Subdomain (www + api) with Cloudflare Proxy (ADR-011)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rydercup-web",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "type": "module",
   "description": "Frontend web para Ryder Cup Amateur Manager",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump version 2.0.17 → 2.0.18
- Move [Unreleased] hotfix changes (PR #207) into CHANGELOG [2.0.18] - 2026-07-07
- Update ROADMAP.md version tracker

## Included fixes (from #207)
- PWA: prevent stale service worker via nginx cache headers
- Competition: allow same-day start and end dates
- UI: reposition Sentry feedback widget to avoid toast overlap
- API: extract readable messages from FastAPI 422 validation errors
- Scoring: show resolved winner name in match summary

## Test plan
- [ ] CI checks pass