### PR TITLE
fix(pwa): Detect iOS platform independently of install banner dismissal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+**PWA — iOS Install Hint Lost After Banner Dismissal**
+
+- `isIOS`/`isDesktopSafari` in `useInstallPrompt` were derived with `!isDismissed() && detectIOS()`, so once a user closed the install banner once (persisted 30 days), platform detection reported `false` from then on. The Landing page's manual "Install" button reused those flags, so it fell back to the generic "already installed or unsupported" hint instead of the correct iOS/Safari instructions. Platform detection is now independent of dismissal state; only `canInstall` (which drives the banner's auto-display) stays dismissal-gated.
+
 ---
 
 ## [2.0.18] - 2026-07-07

--- a/src/hooks/useInstallPrompt.js
+++ b/src/hooks/useInstallPrompt.js
@@ -35,8 +35,8 @@ function detectDesktopSafari() {
 
 export function useInstallPrompt() {
   const [deferredPrompt, setDeferredPrompt] = useState(null);
-  const [isIOS] = useState(() => !isDismissed() && detectIOS());
-  const [isDesktopSafari] = useState(() => !isDismissed() && !detectIOS() && detectDesktopSafari());
+  const [isIOS] = useState(() => detectIOS());
+  const [isDesktopSafari] = useState(() => !detectIOS() && detectDesktopSafari());
   const [canInstall, setCanInstall] = useState(() => !isDismissed() && (detectIOS() || detectDesktopSafari()));
 
   useEffect(() => {

--- a/src/hooks/useInstallPrompt.test.js
+++ b/src/hooks/useInstallPrompt.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useInstallPrompt } from './useInstallPrompt';
+
+const IOS_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 26_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/150.0.7871.51 Mobile/15E148 Safari/604.1';
+
+// Node's experimental global `localStorage` shadows jsdom's — mock explicitly (see AuthContext.test.jsx)
+const localStorageMock = (() => {
+  let store = {};
+  return {
+    getItem: (key) => store[key] || null,
+    setItem: (key, value) => {
+      store[key] = value.toString();
+    },
+    removeItem: (key) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+function setUserAgent(ua) {
+  Object.defineProperty(navigator, 'userAgent', { value: ua, configurable: true });
+}
+
+describe('useInstallPrompt', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setUserAgent(IOS_UA);
+  });
+
+  it('detects iOS platform even when the banner was previously dismissed', () => {
+    localStorage.setItem('pwa_install_dismissed', String(Date.now()));
+
+    const { result } = renderHook(() => useInstallPrompt());
+
+    expect(result.current.isIOS).toBe(true);
+    expect(result.current.canInstall).toBe(false);
+  });
+
+  it('detects iOS platform and allows install prompt when not dismissed', () => {
+    const { result } = renderHook(() => useInstallPrompt());
+
+    expect(result.current.isIOS).toBe(true);
+    expect(result.current.canInstall).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `isIOS`/`isDesktopSafari` in `useInstallPrompt` were gated by `isDismissed()`, so once a user closed the install banner once, the Landing page install CTA showed the generic "already installed or unsupported" hint instead of the correct iOS/Safari instructions.
- Platform detection is now independent of dismissal state; only `canInstall` (which drives the banner's auto-display) stays dismissal-gated.
- Found via a Sentry report on Chrome iOS at `/invitations`.

## Test plan
- [x] Added regression tests in `useInstallPrompt.test.js` covering iOS detection with and without a prior dismissal
- [x] `npx vitest run src/hooks/useInstallPrompt.test.js` passing
- [x] `npx eslint` clean on changed files
- [ ] Manual check on iOS Chrome/Safari that the correct "Add to Home Screen" hint now appears after a previous dismissal

🤖 Generated with [Claude Code](https://claude.com/claude-code)