### PR TITLE
feat(scoring): Show pending players after submitting a scorecard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 **Scoring — Pending Players Shown After Submitting a Scorecard**
 
 - In FOURBALL/FOURSOMES, a match only completes once all 4 players have individually submitted their validated scorecard (each validates their own card against a cross-team marker — by design, not per-pair). After submitting, the Scorecard tab previously only showed "Scorecard already submitted" with no indication that teammates and opponents were still pending, which read as if nothing was happening. It now names the players still pending, or shows a "match finished" message once the match status is `COMPLETED`.
+- The "Match Decided" early-end modal ("continue to submit") kept reappearing on every revisit of an already-submitted scorecard, even though there was nothing left to submit. It's now suppressed once the player has submitted.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+**Scoring — Pending Players Shown After Submitting a Scorecard**
+
+- In FOURBALL/FOURSOMES, a match only completes once all 4 players have individually submitted their validated scorecard (each validates their own card against a cross-team marker — by design, not per-pair). After submitting, the Scorecard tab previously only showed "Scorecard already submitted" with no indication that teammates and opponents were still pending, which read as if nothing was happening. It now names the players still pending, or shows a "match finished" message once the match status is `COMPLETED`.
+
 ---
 
 ## [2.0.18] - 2026-07-07

--- a/src/i18n/locales/en/scoring.json
+++ b/src/i18n/locales/en/scoring.json
@@ -100,6 +100,9 @@
     "cancel": "Cancel",
     "submitted": "Scorecard submitted",
     "alreadySubmitted": "Scorecard already submitted",
+    "matchCompleted": "The match has finished",
+    "waitingForPlayers_one": "Waiting for {{names}} to submit their scorecard",
+    "waitingForPlayers_other": "Waiting for {{count}} players to submit their scorecards: {{names}}",
     "allValidated": "{{count}}/{{total}} holes validated",
     "notReady": "Not all holes are validated yet"
   },

--- a/src/i18n/locales/es/scoring.json
+++ b/src/i18n/locales/es/scoring.json
@@ -100,6 +100,9 @@
     "cancel": "Cancelar",
     "submitted": "Tarjeta enviada",
     "alreadySubmitted": "Tarjeta ya enviada",
+    "matchCompleted": "La partida ha finalizado",
+    "waitingForPlayers_one": "Esperando a que {{names}} entregue su tarjeta",
+    "waitingForPlayers_other": "Esperando a que {{count}} jugadores entreguen su tarjeta: {{names}}",
     "allValidated": "{{count}}/{{total}} hoyos validados",
     "notReady": "No todos los hoyos están validados"
   },

--- a/src/pages/player/ScoringPage.jsx
+++ b/src/pages/player/ScoringPage.jsx
@@ -69,8 +69,10 @@ const ScoringPage = () => {
     }
   }, [activeTab, scoringView?.competitionId]);
 
-  // Derived: show early end modal when match is decided and user hasn't dismissed
-  const showEarlyEnd = !!scoringView?.isDecided && !earlyEndDismissed && !matchSummary;
+  // Derived: show early end modal when match is decided and user hasn't dismissed.
+  // Not shown once the player has already submitted — the "continue to submit" CTA
+  // no longer applies, and re-showing it on every revisit is just noise.
+  const showEarlyEnd = !!scoringView?.isDecided && !earlyEndDismissed && !matchSummary && !hasSubmitted;
 
   const currentUserId = user?.id;
 

--- a/src/pages/player/ScoringPage.jsx
+++ b/src/pages/player/ScoringPage.jsx
@@ -79,6 +79,11 @@ const ScoringPage = () => {
     (ma) => ma.scorerUserId === currentUserId
   );
 
+  // Players who still need to submit their scorecard for the match to complete
+  const pendingPlayers = scoringView?.players?.filter(
+    (p) => !scoringView?.scorecardSubmittedBy?.includes(p.userId)
+  ) ?? [];
+
   // Get current hole data
   const currentHoleData = scoringView?.holes?.find((h) => h.holeNumber === currentHole);
   const currentHoleScore = scoringView?.scores?.find((s) => s.holeNumber === currentHole);
@@ -408,9 +413,19 @@ const ScoringPage = () => {
             )}
 
             {hasSubmitted && (
-              <p className="text-center text-sm text-green-600 font-medium">
-                {t('submit.alreadySubmitted')}
-              </p>
+              <div className="text-center text-sm space-y-1">
+                <p className="text-green-600 font-medium">{t('submit.alreadySubmitted')}</p>
+                {scoringView?.matchStatus === 'COMPLETED' ? (
+                  <p className="text-gray-500">{t('submit.matchCompleted')}</p>
+                ) : pendingPlayers.length > 0 && (
+                  <p className="text-gray-500">
+                    {t('submit.waitingForPlayers', {
+                      count: pendingPlayers.length,
+                      names: pendingPlayers.map((p) => p.userName).join(', '),
+                    })}
+                  </p>
+                )}
+              </div>
             )}
           </div>
         )}

--- a/src/pages/player/ScoringPage.test.jsx
+++ b/src/pages/player/ScoringPage.test.jsx
@@ -182,6 +182,31 @@ describe('ScoringPage', () => {
     expect(screen.getByText('input.nextHole')).toBeInTheDocument();
   });
 
+  describe('early end modal', () => {
+    afterEach(() => {
+      mockUseScoring.hasSubmitted = false;
+      mockUseScoring.scoringView.isDecided = false;
+    });
+
+    it('should show the early end modal when the match is decided and not yet submitted', () => {
+      mockUseScoring.hasSubmitted = false;
+      mockUseScoring.scoringView.isDecided = true;
+
+      render(<ScoringPage />);
+
+      expect(screen.getByTestId('early-end-modal')).toBeInTheDocument();
+    });
+
+    it('should not show the early end modal once the player has already submitted', () => {
+      mockUseScoring.hasSubmitted = true;
+      mockUseScoring.scoringView.isDecided = true;
+
+      render(<ScoringPage />);
+
+      expect(screen.queryByTestId('early-end-modal')).toBeNull();
+    });
+  });
+
   describe('scorecard tab — already submitted', () => {
     afterEach(() => {
       mockUseScoring.hasSubmitted = false;

--- a/src/pages/player/ScoringPage.test.jsx
+++ b/src/pages/player/ScoringPage.test.jsx
@@ -182,6 +182,73 @@ describe('ScoringPage', () => {
     expect(screen.getByText('input.nextHole')).toBeInTheDocument();
   });
 
+  describe('scorecard tab — already submitted', () => {
+    afterEach(() => {
+      mockUseScoring.hasSubmitted = false;
+      mockUseScoring.scoringView.players = [
+        { userId: 'u1', userName: 'Player A', team: 'A' },
+        { userId: 'u2', userName: 'Player B', team: 'B' },
+      ];
+      mockUseScoring.scoringView.scorecardSubmittedBy = [];
+      mockUseScoring.scoringView.matchStatus = 'IN_PROGRESS';
+    });
+
+    it('should show the names of players still pending submission', () => {
+      mockUseScoring.hasSubmitted = true;
+      mockUseScoring.scoringView.matchFormat = 'FOURBALL';
+      mockUseScoring.scoringView.players = [
+        { userId: 'u1', userName: 'Player A', team: 'A' },
+        { userId: 'u2', userName: 'Player B', team: 'A' },
+        { userId: 'u3', userName: 'Player C', team: 'B' },
+        { userId: 'u4', userName: 'Player D', team: 'B' },
+      ];
+      mockUseScoring.scoringView.scorecardSubmittedBy = ['u1'];
+      mockUseScoring.scoringView.matchStatus = 'IN_PROGRESS';
+
+      render(<ScoringPage />);
+      fireEvent.click(screen.getByTestId('tab-scorecard'));
+
+      expect(screen.getByText('submit.alreadySubmitted')).toBeInTheDocument();
+      expect(screen.getByText(/submit\.waitingForPlayers/)).toHaveTextContent(
+        'Player B, Player C, Player D'
+      );
+    });
+
+    it('should show a completed message instead of pending players once the match is COMPLETED', () => {
+      mockUseScoring.hasSubmitted = true;
+      mockUseScoring.scoringView.players = [
+        { userId: 'u1', userName: 'Player A', team: 'A' },
+        { userId: 'u2', userName: 'Player B', team: 'B' },
+      ];
+      mockUseScoring.scoringView.scorecardSubmittedBy = ['u1', 'u2'];
+      mockUseScoring.scoringView.matchStatus = 'COMPLETED';
+
+      render(<ScoringPage />);
+      fireEvent.click(screen.getByTestId('tab-scorecard'));
+
+      expect(screen.getByText('submit.alreadySubmitted')).toBeInTheDocument();
+      expect(screen.getByText('submit.matchCompleted')).toBeInTheDocument();
+      expect(screen.queryByText(/submit\.waitingForPlayers/)).toBeNull();
+    });
+
+    it('should show no secondary message once nobody else is pending', () => {
+      mockUseScoring.hasSubmitted = true;
+      mockUseScoring.scoringView.players = [
+        { userId: 'u1', userName: 'Player A', team: 'A' },
+        { userId: 'u2', userName: 'Player B', team: 'B' },
+      ];
+      mockUseScoring.scoringView.scorecardSubmittedBy = ['u1', 'u2'];
+      mockUseScoring.scoringView.matchStatus = 'IN_PROGRESS';
+
+      render(<ScoringPage />);
+      fireEvent.click(screen.getByTestId('tab-scorecard'));
+
+      expect(screen.getByText('submit.alreadySubmitted')).toBeInTheDocument();
+      expect(screen.queryByText(/submit\.waitingForPlayers/)).toBeNull();
+      expect(screen.queryByText('submit.matchCompleted')).toBeNull();
+    });
+  });
+
   describe('match summary screen', () => {
     afterEach(() => {
       mockUseScoring.matchSummary = null;


### PR DESCRIPTION
## Summary
- In FOURBALL/FOURSOMES a match only completes once all 4 players have individually submitted their validated scorecard — each validates their own card against a cross-team marker, by design (dual independent validation). This part is intentional and unchanged.
- After submitting, the Scorecard tab only showed "Scorecard already submitted" with no indication of who else was still pending, which read as if nothing was happening for the other 3 players.
- Now shows the names of players still pending, or a "match finished" message once `matchStatus` is `COMPLETED`.

## Test plan
- [x] Added `ScoringPage.test.jsx` cases: pending players listed, completed-match message, no secondary message once nobody is pending
- [x] `npx vitest run src/pages/player/ScoringPage.test.jsx` (15/15 passing)
- [x] `npx eslint` clean on changed files
- [ ] Manual check in a FOURBALL/FOURSOMES match: submit as one player, confirm the other 3 names show up, then finish submitting and confirm the "match finished" message replaces it

🤖 Generated with [Claude Code](https://claude.com/claude-code)